### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@zenuml/core",
   "version": "3.0.0",
   "private": false,
+  "license": "MIT",
   "repository": {
     "url": "https://github.com/mermaid-js/zenuml-core"
   },


### PR DESCRIPTION
Add license field to package.json so that the license will display on the npm registry page.