### PR TITLE
fix: remove gaps around messages

### DIFF
--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Creation/Creation.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Creation/Creation.vue
@@ -9,6 +9,7 @@
       'right-to-left': rightToLeft,
       '-translate-x-full': rightToLeft,
       highlight: isCurrent,
+      'inited-from-occurrence': isInitedFromOccurrence,
     }"
     :style="{ width: interactionWidth + 'px' }"
   >
@@ -96,6 +97,9 @@ export default {
     },
     isCurrent() {
       return this.creation.isCurrent(this.cursor);
+    },
+    isInitedFromOccurrence: function () {
+      return this.creation.isInitedFromOccurrence(this.from);
     },
   },
   mounted() {

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Interaction/Interaction.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Interaction/Interaction.vue
@@ -5,7 +5,7 @@
     :data-to="to"
     data-type="interaction"
     :data-signature="signature"
-    :class="{ highlight: isCurrent, self: isSelf }"
+    :class="{ highlight: isCurrent, self: isSelf, 'inited-from-occurrence': isInitedFromOccurrence }"
     :style="{
       width: !isSelf && (interactionWidth + 'px'),
       transform: 'translateX(' + translateX + 'px)',
@@ -136,6 +136,9 @@ export default {
     invocation: function () {
       // return 'Message'
       return this.isSelf ? 'SelfInvocation' : 'Message';
+    },
+    isInitedFromOccurrence: function () {
+      return this.message?.isInitedFromOccurrence(this.from);
     },
   },
   methods: {

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/InteractionAsync/Interaction-async.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/InteractionAsync/Interaction-async.vue
@@ -3,7 +3,7 @@
     class="interaction async"
     v-on:click.stop="onClick"
     :data-signature="signature"
-    :class="{ 'right-to-left': rightToLeft, highlight: isCurrent }"
+    :class="{ 'right-to-left': rightToLeft, highlight: isCurrent, 'self-invocation': isSelf }"
     :style="{ width: interactionWidth + 'px', transform: 'translateX(' + translateX + 'px)' }"
   >
     <comment v-if="comment" :comment="comment" />

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Return/Return.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Return/Return.vue
@@ -4,7 +4,7 @@
     class="interaction return relative"
     v-on:click.stop="onClick"
     :data-signature="signature"
-    :class="{ 'right-to-left': rightToLeft, highlight: isCurrent }"
+    :class="{ 'right-to-left': rightToLeft, highlight: isCurrent, 'return-to-start': isReturnToStart }"
     :style="{ width: width + 'px', left: left + 'px' }"
   >
     <comment v-if="comment" :comment="comment" />
@@ -34,11 +34,12 @@ import { mapGetters } from 'vuex';
 import { CodeRange } from '../../../../../../../parser/CodeRange';
 import WidthProviderOnBrowser from '../../../../../../../positioning/WidthProviderFunc';
 import { TextType } from '../../../../../../../positioning/Coordinate';
+
 export default {
   name: 'return',
   props: ['context', 'comment'],
   computed: {
-    ...mapGetters(['distance', 'cursor', 'onElementClick']),
+    ...mapGetters(['distance', 'cursor', 'onElementClick', 'participants']),
     from: function () {
       return this.context.Origin();
     },
@@ -76,6 +77,9 @@ export default {
     isSelf: function () {
       return this.source === this.target;
     },
+    isReturnToStart() {
+      return this.target === this.participants.Starter().name;
+    }
   },
   methods: {
     onClick() {

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/MessageLayer.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/MessageLayer.vue
@@ -61,11 +61,28 @@ export default {
    */
 .interaction {
   /*Keep dashed or solid here otherwise no space is given to the border*/
-  border: dashed transparent;
+  border: dashed transparent 0;
+}
+
+.interaction.sync {
   /* This border width configuration make sure the content width is
        the same as from the source occurrence's right border to target
        occurrence's left boarder (boarder not inclusive).*/
-  border-width: 0 7px;
+  border-right-width: 7px;
+}
+
+.interaction.inited-from-occurrence,
+.interaction.self-invocation {
+  border-left-width: 7px;
+}
+
+.interaction.return {
+  border-left-width: 7px;
+  border-right-width: 7px;
+}
+
+.interaction.return-to-start {
+  border-left-width: 0;
 }
 
 .interaction:hover {

--- a/src/parser/IsInitedFromOccurrence.js
+++ b/src/parser/IsInitedFromOccurrence.js
@@ -1,0 +1,40 @@
+import { default as sequenceParser } from '../generated-parser/sequenceParser';
+const seqParser = sequenceParser;
+
+const CreationContext = seqParser.CreationContext;
+CreationContext.prototype.Body = CreationContext.prototype.creationBody;
+CreationContext.prototype.isInitedFromOccurrence = function (from) {
+  return isInitedFromOccurrence.bind(this)(from);
+};
+
+const MessageContext = seqParser.MessageContext;
+MessageContext.prototype.Body = MessageContext.prototype.messageBody;
+MessageContext.prototype.isInitedFromOccurrence = function (from) {
+  return isInitedFromOccurrence.bind(this)(from);
+};
+
+/**
+ * if a message is sent from a participant who is also a target of a message, we can
+ * say that the message is inited from an occurrence
+ **/
+function isInitedFromOccurrence(from) {
+  let current = this;
+  while (current != null) {
+    if (current instanceof seqParser.StatContext) {
+      let participant;
+      if (current.message && current.message()) {
+        participant = current.message().Owner();
+      } else if (current.creation && current.creation()) {
+        participant = current.creation().Owner();
+      } else if (current.asyncMessage && current.asyncMessage()) {
+        participant = current.asyncMessage().to().getFormattedText();
+      }
+      if (participant === from) {
+        return true;
+      }
+    }
+    current = current.parentCtx;
+  }
+  return false;
+}
+

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -14,6 +14,7 @@ import './SignatureText';
 import './Messages/MessageContext';
 import './From';
 import './key/Key';
+import './IsInitedFromOccurrence';
 import './utils/cloest-ancestor/ClosestAncestor';
 import { formatText } from '../utils/StringUtil';
 


### PR DESCRIPTION
Fix #6 

Tested for following diagrams.

```
Client->SGW."Get order by id" {
  svc.Get(id) {
    new X()
    rep."load order" {
      =="Start Here"==
      MF."load order from mainframe"
      =="End Here"==
      if(order == null) {
        @return 
        SGW->Client:404
      } else {
        return order
      }
      
      while(true) {
        svc.refresh(data)
      }
      processOrder()
    }
    return order
  }
  return response
}
```
Before:
<img width="1582" alt="Screenshot 2023-07-01 at 9 08 56 pm" src="https://github.com/mermaid-js/zenuml-core/assets/465125/6f46728b-66a2-4cee-adba-820f96025ff1">
After:
<img width="1582" alt="Screenshot 2023-07-01 at 9 51 12 pm" src="https://github.com/mermaid-js/zenuml-core/assets/465125/be566a3e-3018-45de-a96a-2d199f10f993">
```
A->B: Async Messages (Gap on both sides)
C."sync message(Gap on From)" {
  B->D."sync message with explict From(Gap on From)"
  B->B: Async Self message (No Gap here)
}
```
Before:
<img width="1582" alt="Screenshot 2023-07-01 at 9 09 56 pm" src="https://github.com/mermaid-js/zenuml-core/assets/465125/e61d9fb3-5667-4d23-9ee6-de2d6e94d373">
After:
<img width="1582" alt="Screenshot 2023-07-01 at 9 09 42 pm" src="https://github.com/mermaid-js/zenuml-core/assets/465125/932cb709-6ba7-4c71-8ebd-48c4e1dd9794">

