### PR TITLE
fix scaling buttons move when scaling

### DIFF
--- a/src/components/DiagramFrame/DiagramFrame.vue
+++ b/src/components/DiagramFrame/DiagramFrame.vue
@@ -156,7 +156,7 @@ export default {
       });
     },
     zoomIn() {
-      const newScale = this.scale + 0.1 > 1 ? 1 : this.scale + 0.1;
+      const newScale = Math.min(1, this.scale + 0.1);
       this.setScale(newScale);
     },
     zoomOut() {

--- a/src/components/DiagramFrame/DiagramFrame.vue
+++ b/src/components/DiagramFrame/DiagramFrame.vue
@@ -9,6 +9,13 @@
      -->
     <debug />
     <div
+      class="zoom-controls bg-skin-base text-skin-control flex justify-between w-28 hide-export bg-slate-50 rounded ml-1"
+    >
+      <button class="zoom-in px-3" @click="zoomIn()">+</button>
+      <label>{{ Number(scale * 100).toFixed(0) }} %</label>
+      <button class="zoom-out px-3" @click="zoomOut()">-</button>
+    </div>
+    <div
       class="frame text-skin-frame bg-skin-frame border-skin-frame relative m-1 origin-top-left whitespace-nowrap border rounded"
       :style="{ transform: `scale(${scale})` }"
     >
@@ -63,14 +70,6 @@
             <path d="M541.3 328m-68 0a68 68 0 1 0 136 0 68 68 0 1 0-136 0Z" fill="#2867CE" />
           </svg>
         </button>
-        <div
-          class="zoom-controls bg-skin-base text-skin-control flex justify-between w-28 hide-export"
-          :style="{ transform: `scale(${1 / scale})` }"
-        >
-          <button class="zoom-in px-1" @click="zoomIn()">+</button>
-          <label>{{ Number(scale * 100).toFixed(0) }} %</label>
-          <button class="zoom-out px-1" @click="zoomOut()">-</button>
-        </div>
         <width-provider />
         <a
           target="_blank"

--- a/src/components/DiagramFrame/DiagramFrame.vue
+++ b/src/components/DiagramFrame/DiagramFrame.vue
@@ -9,7 +9,7 @@
      -->
     <debug />
     <div
-      class="zoom-controls bg-skin-base text-skin-control flex justify-between w-28 hide-export bg-slate-50 rounded ml-1"
+      class="zoom-controls bg-skin-base text-skin-control flex justify-between w-28 hide-export ml-1"
     >
       <button class="zoom-in px-3" @click="zoomIn()">+</button>
       <label>{{ Number(scale * 100).toFixed(0) }} %</label>

--- a/src/components/DiagramFrame/DiagramFrame.vue
+++ b/src/components/DiagramFrame/DiagramFrame.vue
@@ -9,7 +9,7 @@
      -->
     <debug />
     <div
-      class="zoom-controls bg-skin-base text-skin-control flex justify-between w-28 hide-export ml-1"
+      class="zoom-controls bg-skin-base text-skin-control flex justify-between w-28 hide-export bg-slate-50 rounded ml-1"
     >
       <button class="zoom-in px-3" @click="zoomIn()">+</button>
       <label>{{ Number(scale * 100).toFixed(0) }} %</label>

--- a/src/components/DiagramFrame/DiagramFrame.vue
+++ b/src/components/DiagramFrame/DiagramFrame.vue
@@ -10,7 +10,6 @@
     <debug />
     <div
       class="frame text-skin-frame bg-skin-frame border-skin-frame relative m-1 origin-top-left whitespace-nowrap border rounded"
-      :style="{ transform: `scale(${scale})` }"
     >
       <div ref="content">
         <div
@@ -36,7 +35,7 @@
             <TipsDialog />
           </div>
         </div>
-        <seq-diagram ref="diagram" />
+        <seq-diagram ref="diagram" :style="{ transform: `scale(${scale})`}" class="origin-top-left"/>
       </div>
       <div class="footer p-1 flex justify-between">
         <button class="bottom-1 left-1 hide-export" @click="showTipsDialog()">
@@ -65,7 +64,6 @@
         </button>
         <div
           class="zoom-controls bg-skin-base text-skin-control flex justify-between w-28 hide-export"
-          :style="{ transform: `scale(${1 / scale})` }"
         >
           <button class="zoom-in px-1" @click="zoomIn()">+</button>
           <label>{{ Number(scale * 100).toFixed(0) }} %</label>
@@ -158,7 +156,8 @@ export default {
       });
     },
     zoomIn() {
-      this.setScale(this.scale + 0.1);
+      const newScale = this.scale + 0.1 > 1 ? 1 : this.scale + 0.1;
+      this.setScale(newScale);
     },
     zoomOut() {
       this.setScale(this.scale - 0.1);

--- a/src/components/DiagramFrame/DiagramFrame.vue
+++ b/src/components/DiagramFrame/DiagramFrame.vue
@@ -9,13 +9,6 @@
      -->
     <debug />
     <div
-      class="zoom-controls bg-skin-base text-skin-control flex justify-between w-28 hide-export bg-slate-50 rounded ml-1"
-    >
-      <button class="zoom-in px-3" @click="zoomIn()">+</button>
-      <label>{{ Number(scale * 100).toFixed(0) }} %</label>
-      <button class="zoom-out px-3" @click="zoomOut()">-</button>
-    </div>
-    <div
       class="frame text-skin-frame bg-skin-frame border-skin-frame relative m-1 origin-top-left whitespace-nowrap border rounded"
       :style="{ transform: `scale(${scale})` }"
     >
@@ -70,6 +63,14 @@
             <path d="M541.3 328m-68 0a68 68 0 1 0 136 0 68 68 0 1 0-136 0Z" fill="#2867CE" />
           </svg>
         </button>
+        <div
+          class="zoom-controls bg-skin-base text-skin-control flex justify-between w-28 hide-export"
+          :style="{ transform: `scale(${1 / scale})` }"
+        >
+          <button class="zoom-in px-1" @click="zoomIn()">+</button>
+          <label>{{ Number(scale * 100).toFixed(0) }} %</label>
+          <button class="zoom-out px-1" @click="zoomOut()">-</button>
+        </div>
         <width-provider />
         <a
           target="_blank"


### PR DESCRIPTION
Now we put the scale button back to the middle of the bottom.
And make it max scaling to 100%, and changed the scale scope so that frame and button do not move when scaled.
