### PR TITLE
fix: limit `antlr4` to version `~4.11.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/assert": "^1.5.4",
     "@types/ramda": "^0.28.0",
     "@vue/compat": "^3.2.45",
-    "antlr4": "^4.11.0",
+    "antlr4": "~4.11.0",
     "color-string": "^1.5.5",
     "dom-to-image-more": "^2.9.5",
     "file-saver": "^2.0.5",
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.19.1",
     "@babel/preset-env": "^7.20.2",
-    "@types/antlr4": "^4.11.2",
+    "@types/antlr4": "~4.11.2",
     "@types/color-string": "^1.5.2",
     "@types/lodash": "^4.14.168",
     "@types/node": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ dependencies:
     specifier: ^3.2.45
     version: 3.2.45(vue@3.2.45)
   antlr4:
-    specifier: ^4.11.0
+    specifier: ~4.11.0
     version: 4.11.0
   color-string:
     specifier: ^1.5.5
@@ -61,7 +61,7 @@ devDependencies:
     specifier: ^7.20.2
     version: 7.20.2(@babel/core@7.22.1)
   '@types/antlr4':
-    specifier: ^4.11.2
+    specifier: ~4.11.2
     version: 4.11.2
   '@types/color-string':
     specifier: ^1.5.2


### PR DESCRIPTION
ANTLR versioning does not strictly follow semver semantics (see https://github.com/antlr/antlr4/blob/dev/README.md):

> * backwards compatibility is only guaranteed for patch version bumps (4.11.1 -> 4.11.2)
>
> _Taken from https://github.com/antlr/antlr4/blob/ce7f5e73cd4787c5aebdc05c29d4d898d6f2d123/README.md?plain=1#L33_

Because of that, we can't use `^` (caret) in a version requirements. Instead, we can use [`~` tilde ranges][1].

Staying on v4.11.x is required, becasue `antlr4` v4.12.0 no longer supports Node.JS v14, see https://github.com/antlr/antlr4/pull/4355.

[1]: https://github.com/npm/node-semver#tilde-ranges-123-12-1