### PR TITLE
chore(vite): disable output `SVG` to `Base64`

### DIFF
--- a/vite.config.lib.js
+++ b/vite.config.lib.js
@@ -1,23 +1,24 @@
 /* eslint-env es6 */
-import { resolve } from 'path';
-import { defineConfig } from 'vite';
-import createVuePlugin from '@vitejs/plugin-vue';
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import createVuePlugin from "@vitejs/plugin-vue";
+import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
+import svgLoader from "vite-svg-loader";
 
 export default defineConfig({
   build: {
     // https://vitejs.dev/guide/build.html#library-mode
     lib: {
-      entry: resolve(__dirname, 'src/core.ts'),
+      entry: resolve(__dirname, "src/core.ts"),
       // https://vitejs.dev/config/build-options.html#build-lib
       // the exposed global variable and is required when formats includes 'umd' or 'iife'.
-      name: 'ZenUML',
-      fileName: 'zenuml',
+      name: "ZenUML",
+      fileName: "zenuml",
     },
     rollupOptions: {
       output: [
         {
-          format: 'esm',
+          format: "esm",
           sourcemap: true,
           // https://rollupjs.org/guide/en/#outputentryfilenames
           // It will use the file name in `build.lib.entry` without extension as `[name]` if `[name].xxx.yyy` is provided.
@@ -27,8 +28,8 @@ export default defineConfig({
           entryFileNames: `zenuml.esm.mjs`,
         },
         {
-          name: 'zenuml', //  it is the global variable name representing your bundle. https://rollupjs.org/guide/en/#outputname
-          format: 'umd',
+          name: "zenuml", //  it is the global variable name representing your bundle. https://rollupjs.org/guide/en/#outputname
+          format: "umd",
           sourcemap: true,
           entryFileNames: `zenuml.js`,
         },
@@ -37,11 +38,12 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      vue: '@vue/compat',
-      '@': resolve(__dirname, './src')
+      vue: "@vue/compat",
+      "@": resolve(__dirname, "./src"),
     },
   },
   plugins: [
+    svgLoader(),
     createVuePlugin({
       template: {
         compilerOptions: {
@@ -54,6 +56,6 @@ export default defineConfig({
     cssInjectedByJsPlugin(),
   ],
   define: {
-    'process.env.NODE_ENV': '"production"'
-  }
+    "process.env.NODE_ENV": '"production"',
+  },
 });


### PR DESCRIPTION
`@zenuml/core` bundle file should not include Base64-encoded SVG, as it may cause rendering errors in web-sequence.
## Before
<img width="1421" alt="image" src="https://github.com/mermaid-js/zenuml-core/assets/125171539/30b36d75-cc62-4d43-9e3c-fe1e682932e9">

## After
<img width="1435" alt="image" src="https://github.com/mermaid-js/zenuml-core/assets/125171539/41c6b74a-bc5c-4d1e-bff1-ae7c3ed4d5d8">

