### PR TITLE
fix: alignment issue #88 #89

### DIFF
--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/MessageLayer.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/MessageLayer.vue
@@ -56,11 +56,42 @@ onUpdated(() => {
     border-right-width: 7px;
   }
 
+  .occurrence .interaction.sync.self {
+    border-left-width: 7px;
+  }
+
+  .occurrence {
+    .interaction.sync.self {
+      border-left-width: 7px;
+    }
+    .interaction.async {
+      border-right-width: 0;
+    }
+  }
+
+  .occurrence {
+    .occurrence {
+      .interaction.sync.self {
+        border-left-width: 7px;
+      }
+      .interaction.async {
+        border-right-width: 7px;
+      }
+    }
+  }
+  .interaction.sync.self {
+    border-left-width: 0;
+  }
+
+  .interaction.async {
+    border-left-width: 8px;
+  }
+
   .interaction.sync.right-to-left {
     /* This border width configuration make sure the content width is
        the same as from the source occurrence's right border to target
        occurrence's left boarder (boarder not inclusive).*/
-    border-right-width: 0;
+    border-right-width: 7px;
     border-left-width: 7px;
   }
 


### PR DESCRIPTION
Already verified the cases mentioned in Issues #88 and #89, as well as the template code available at https://app.zenuml.com/.

## Test 1
```
A->A.method()

A.method() {
  B:method
  self() {
    // [bold, red] similar issue
    B:method
  }
}

// Issue #88
A->A.method {
  // [bold, red]Issue #89
  B:async message
}
```
<details><summary>📸 Screenshots</summary>
<p>
<img width="665" alt="image" src="https://github.com/mermaid-js/zenuml-core/assets/125171539/be9b9a88-7563-4552-88a0-0089f2ad3f71">
</p>
</details> 

## Test 2
```
// This is a sample
A.method() {
  if(condition) {
    B.method()
  }
}
```
<details><summary>📸 Screenshots</summary>
<p>
<img width="755" alt="image" src="https://github.com/mermaid-js/zenuml-core/assets/125171539/f1262642-78ee-41d8-8ecc-50e68a2adbe2">
</p>
</details> 

## Test-3 
```
Client->SGW."Get order by id" {
  svc.Get(id) {
    new X()
    rep."load order" {
      =="Start Here"==
      MF."load order from mainframe"
      =="End Here"==
      if(order == null) {
        @return 
        SGW->Client:404
      } else {
        return order
      }
      
      while(true) {
        svc.refresh(data)
      }
      processOrder()
    }
    return order
  }
  return response
}
```
<details><summary>📸 Screenshots</summary>
<p>
<img width="1720" alt="image" src="https://github.com/mermaid-js/zenuml-core/assets/125171539/ed57d67a-fa09-464b-a98c-6a3481cb1c75">
</p>
</details> 

## Test 4
```
// This is a sample
A.do() {
  if (condition1) {
    X.doSomething()
  } else if (condition2) {
    Y.doSomethingElse
  } else {
    doNothing()
  }
}
```
<details><summary>📸 Screenshots</summary>
<p>
<img width="1197" alt="image" src="https://github.com/mermaid-js/zenuml-core/assets/125171539/58be8cd6-9786-4448-88ef-e70ef9687ba4">
</p>
</details> 
