### PR TITLE
Fix/alt fragment overflows the diagram frame

### DIFF
--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentMixin.js
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentMixin.js
@@ -1,55 +1,64 @@
-import { Participants } from '@/parser';
-import { mapGetters } from 'vuex';
+import { Participants } from "@/parser";
+import { mapGetters } from "vuex";
 import FrameBuilder from "@/parser/FrameBuilder";
 import FrameBorder from "@/positioning/FrameBorder";
-import {Coordinates} from "@/positioning/Coordinates";
-import WidthProviderOnBrowser from "@/positioning/WidthProviderFunc";
-import {TotalWidth} from "@/components/DiagramFrame/SeqDiagram/WidthOfContext";
-import CollapseButton from './CollapseButton.vue';
-import EventBus from '../../../../../../../EventBus';
+import { TotalWidth } from "@/components/DiagramFrame/SeqDiagram/WidthOfContext";
+import CollapseButton from "./CollapseButton.vue";
+import EventBus from "../../../../../../../EventBus";
 
 export default {
   computed: {
-    ...mapGetters(['coordinates']),
+    ...mapGetters(["coordinates"]),
     offsetX: function () {
       const allParticipants = this.coordinates.orderedParticipantNames();
       let frameBuilder = new FrameBuilder(allParticipants);
       const frame = frameBuilder.getFrame(this.context);
       const border = FrameBorder(frame);
-      const localParticipants = [this.context.Origin(), ...Participants(this.context).Names()]
-      const leftParticipant = allParticipants.find((p) => localParticipants.includes(p));
+      const localParticipants = [
+        this.context.Origin(),
+        ...Participants(this.context).Names(),
+      ];
+      const leftParticipant = allParticipants.find((p) =>
+        localParticipants.includes(p),
+      );
       // TODO: consider using this.getParticipantGap(this.participantModels[0])
-      let halfLeftParticipant = Coordinates.half(WidthProviderOnBrowser, leftParticipant);
-      console.debug(`left participant: ${leftParticipant} ${halfLeftParticipant}`);
-      return this.coordinates.distance(leftParticipant, this.from) + border.left + halfLeftParticipant;
+      let halfLeftParticipant = this.coordinates.half(leftParticipant);
+      console.debug(
+        `left participant: ${leftParticipant} ${halfLeftParticipant}`,
+      );
+      return (
+        this.coordinates.distance(leftParticipant, this.from) +
+        border.left +
+        halfLeftParticipant
+      );
     },
     fragmentStyle: function () {
       return {
         // +1px for the border of the fragment
-        transform: 'translateX(' + (this.offsetX + 1) * -1 + 'px)',
-        width: TotalWidth(this.context, this.coordinates) + 'px',
+        transform: "translateX(" + (this.offsetX + 1) * -1 + "px)",
+        width: TotalWidth(this.context, this.coordinates) + "px",
       };
     },
   },
-  data: function() {
-    return {collapsed: false};
+  data: function () {
+    return { collapsed: false };
   },
   methods: {
-    toggle($event) {
+    toggle() {
       this.collapsed = !this.collapsed;
 
       //update participant top in two cases: 1) has child creation statement 2) has sibling creation statement
-      //e.g. 1): if(a) { new B } 
+      //e.g. 1): if(a) { new B }
       //     2): if(a) { while(b) { A.foo }; new B }
-      EventBus.$emit('participant_set_top');
-    }
+      EventBus.$emit("participant_set_top");
+    },
   },
   components: { CollapseButton },
   watch: {
-    context(v) {
-      if(this.collapsed) {
+    context() {
+      if (this.collapsed) {
         this.collapsed = false;
       }
-    }
+    },
   },
 };

--- a/src/components/DiagramFrame/SeqDiagram/WidthOfContext.ts
+++ b/src/components/DiagramFrame/SeqDiagram/WidthOfContext.ts
@@ -16,7 +16,6 @@ export function TotalWidth(ctx: any, coordinates: Coordinates) {
       .slice()
       .reverse()
       .find((p) => localParticipants.includes(p)) || "";
-  // console.debug(`allParticipants: ${JSON.stringify(allParticipants)}, localParticipants: ${JSON.stringify(localParticipants)}, leftParticipant: ${leftParticipant}, rightParticipant: ${rightParticipant}`);
   const frameBuilder = new FrameBuilder(allParticipants as string[]);
   const frame = frameBuilder.getFrame(ctx);
   const border = FrameBorder(frame as Frame);
@@ -25,13 +24,7 @@ export function TotalWidth(ctx: any, coordinates: Coordinates) {
     rightParticipant,
     coordinates,
   );
-  console.debug(
-    `frame: ${JSON.stringify(
-      frame,
-    )} extraWidth: ${extraWidth}, leftParticipant: ${leftParticipant}, rightParticipant: ${rightParticipant}, border: ${JSON.stringify(
-      border,
-    )}`,
-  );
+
   return (
     coordinates.distance(leftParticipant, rightParticipant) +
     border.left +

--- a/src/components/DiagramFrame/SeqDiagram/WidthOfContext.ts
+++ b/src/components/DiagramFrame/SeqDiagram/WidthOfContext.ts
@@ -1,36 +1,62 @@
-import {AllMessages} from "@/positioning/MessageContextListener";
+import { AllMessages } from "@/positioning/MessageContextListener";
 import WidthProviderOnBrowser from "../../../positioning/WidthProviderFunc";
-import {TextType} from "@/positioning/Coordinate";
-import {Participants} from "@/parser";
+import { TextType } from "@/positioning/Coordinate";
+import { Participants } from "@/parser";
 import FrameBuilder from "@/parser/FrameBuilder";
-import FrameBorder, {Frame} from "@/positioning/FrameBorder";
-import {Coordinates} from "@/positioning/Coordinates";
+import FrameBorder, { Frame } from "@/positioning/FrameBorder";
+import { Coordinates } from "@/positioning/Coordinates";
 
 export function TotalWidth(ctx: any, coordinates: Coordinates) {
   const allParticipants = coordinates.orderedParticipantNames();
-  const localParticipants = [ctx.Origin(),...Participants(ctx).Names()]
-  const leftParticipant = allParticipants.find((p) => localParticipants.includes(p)) || '';
-  const rightParticipant = allParticipants.slice().reverse().find((p) => localParticipants.includes(p)) || '';
+  const localParticipants = [ctx.Origin(), ...Participants(ctx).Names()];
+  const leftParticipant =
+    allParticipants.find((p) => localParticipants.includes(p)) || "";
+  const rightParticipant =
+    allParticipants
+      .slice()
+      .reverse()
+      .find((p) => localParticipants.includes(p)) || "";
   // console.debug(`allParticipants: ${JSON.stringify(allParticipants)}, localParticipants: ${JSON.stringify(localParticipants)}, leftParticipant: ${leftParticipant}, rightParticipant: ${rightParticipant}`);
-  let frameBuilder = new FrameBuilder(allParticipants as string[]);
+  const frameBuilder = new FrameBuilder(allParticipants as string[]);
   const frame = frameBuilder.getFrame(ctx);
   const border = FrameBorder(frame as Frame);
-  const extraWidth = extraWidthDueToSelfMessage(ctx, rightParticipant, coordinates);
-  console.debug(`frame: ${JSON.stringify(frame)} extraWidth: ${extraWidth}, leftParticipant: ${leftParticipant}, rightParticipant: ${rightParticipant}, border: ${JSON.stringify(border)}`);
-  return coordinates.distance(leftParticipant, rightParticipant) +
+  const extraWidth = extraWidthDueToSelfMessage(
+    ctx,
+    rightParticipant,
+    coordinates,
+  );
+  console.debug(
+    `frame: ${JSON.stringify(
+      frame,
+    )} extraWidth: ${extraWidth}, leftParticipant: ${leftParticipant}, rightParticipant: ${rightParticipant}, border: ${JSON.stringify(
+      border,
+    )}`,
+  );
+  return (
+    coordinates.distance(leftParticipant, rightParticipant) +
     border.left +
     border.right +
-    Coordinates.half(WidthProviderOnBrowser, leftParticipant) +
-    Coordinates.half(WidthProviderOnBrowser, rightParticipant) +
-    extraWidth;
+    coordinates.half(leftParticipant) +
+    coordinates.half(rightParticipant) +
+    extraWidth
+  );
 }
 
-function extraWidthDueToSelfMessage(ctx: any, rightParticipant: string, coordinates: Coordinates) {
+function extraWidthDueToSelfMessage(
+  ctx: any,
+  rightParticipant: string,
+  coordinates: Coordinates,
+) {
   const allMessages = AllMessages(ctx);
   const widths = allMessages
     .filter((m) => m.from === m.to)
     // 37 is arrow width (30) + half occurrence width(7)
-    .map((s) => WidthProviderOnBrowser(s.signature, TextType.MessageContent) + 37
-      - coordinates.distance(s.from, rightParticipant) - Coordinates.half(WidthProviderOnBrowser, rightParticipant))
+    .map(
+      (s) =>
+        WidthProviderOnBrowser(s.signature, TextType.MessageContent) +
+        37 -
+        coordinates.distance(s.from, rightParticipant) -
+        coordinates.half(rightParticipant),
+    );
   return Math.max.apply(null, [0, ...widths]);
 }

--- a/src/positioning/Coordinates.ts
+++ b/src/positioning/Coordinates.ts
@@ -32,17 +32,16 @@ export class Coordinates {
   }
 
   getPosition(participantName: string | undefined): number {
-    const participantNameOrLabel = this.labelOrName(participantName || "");
-    const cacheKey = `getPosition_${participantNameOrLabel}`;
-    const cachedPosition = getCache(cacheKey);
-    if (cachedPosition != null) {
-      return cachedPosition;
-    }
     const pIndex = this.participantModels.findIndex(
       (p) => p.name === participantName,
     );
     if (pIndex === -1) {
       throw Error(`Participant ${participantName} not found`);
+    }
+    const cacheKey = `getPosition_${participantName}`;
+    const cachedPosition = getCache(cacheKey);
+    if (cachedPosition != null) {
+      return cachedPosition;
     }
     const leftGap = this.getParticipantGap(this.participantModels[0]);
     const position = leftGap + find_optimal(this.m)[pIndex];


### PR DESCRIPTION
Fix participant positioning by changing static method `half()` to instance method and calculating the width of participant by label instead of name
#90
![image](https://github.com/mermaid-js/zenuml-core/assets/3481791/9ed83d6c-2f46-4813-8252-c0db68a2fa78)


