### PR TITLE
Fixes rendering issue for mermaid

### DIFF
--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
@@ -1,10 +1,19 @@
 <template>
   <div
     class="life-line-layer lifeline-layer z-30 absolute h-full flex flex-col top-0"
-    :style="{ 'min-width': '200px', 'width': `calc(100% - ${leftGap}px)`, pointerEvents: renderParticipants ? 'none' : 'all' }"
+    :style="{
+      'min-width': '200px',
+      width: `calc(100% - ${leftGap}px)`,
+      pointerEvents: renderParticipants ? 'none' : 'all',
+    }"
   >
     <!--  header sticky blur effect, DON'T remove, gap + participant height = 72px  -->
-    <div :style="{transform: `translateY(${translate > 0 ? translate - 1 : translate}px)` }" class="pt-8 after:bg-gradient-to-b after:from-skin-frame after:via-skin-frame after:to-skin-frame/0 after:block after:absolute after:top-0 after:w-full after:h-[72px]"></div>
+    <div
+      :style="{
+        transform: `translateY(${translate > 0 ? translate - 1 : translate}px)`,
+      }"
+      class="pt-8 after:bg-gradient-to-b after:from-skin-frame after:via-skin-frame after:to-skin-frame/0 after:block after:absolute after:top-0 after:w-full after:h-[72px]"
+    ></div>
     <div class="container relative grow">
       <life-line
         v-if="starterOnTheLeft"
@@ -37,48 +46,61 @@
   </div>
 </template>
 
-
 <script>
-import parentLogger from '../../../../logger/logger';
-import { GroupContext, ParticipantContext, Participants } from '@/parser';
-import {mapGetters, mapMutations, useStore} from 'vuex';
-import LifeLine from './LifeLine.vue';
-import LifeLineGroup from './LifeLineGroup.vue';
-const logger = parentLogger.child({ name: 'LifeLineLayer' });
+import parentLogger from "../../../../logger/logger";
+import { GroupContext, ParticipantContext, Participants } from "@/parser";
+import { mapGetters, mapMutations, useStore } from "vuex";
+import LifeLine from "./LifeLine.vue";
+import LifeLineGroup from "./LifeLineGroup.vue";
+const logger = parentLogger.child({ name: "LifeLineLayer" });
 
 // TODO: remove the same logic
-const PARTICIPANT_HEIGHT = 70
-const INTERSECTION_ERROR_MARGIN = 10 // a threshold for judging whether the participant is intersecting with the viewport
-import {computed} from "vue";
+const PARTICIPANT_HEIGHT = 70;
+const INTERSECTION_ERROR_MARGIN = 10; // a threshold for judging whether the participant is intersecting with the viewport
+import { computed } from "vue";
 import useIntersectionTop from "@/functions/useIntersectionTop";
 import useDocumentScroll from "@/functions/useDocumentScroll";
-import {getElementDistanceToTop} from "@/utils/dom";
+import { getElementDistanceToTop } from "@/utils/dom";
 
 export default {
-  name: 'life-line-layer',
-  props: ['context', 'renderParticipants', 'leftGap'],
-  setup () {
-    const participantOffsetTop = 0
-    const store = useStore()
-    const intersectionTop = useIntersectionTop()
-    const [scrollTop] = useDocumentScroll()
+  name: "life-line-layer",
+  props: ["context", "renderParticipants", "leftGap"],
+  setup() {
+    const participantOffsetTop = 0;
+    const store = useStore();
+    const intersectionTop = useIntersectionTop();
+    const [scrollTop] = useDocumentScroll();
     const translate = computed(() => {
-      let top = intersectionTop.value + scrollTop.value
-      if (intersectionTop.value > INTERSECTION_ERROR_MARGIN && store?.state.stickyOffset) top += store?.state.stickyOffset
-      const diagramHeight = store?.state.diagramElement?.clientHeight || 0
-      const diagramTop = store?.state.diagramElement ? getElementDistanceToTop(store?.state.diagramElement) : 0
-      if (top < participantOffsetTop + diagramTop) return 0
-      return Math.min(top - diagramTop, diagramHeight - PARTICIPANT_HEIGHT) - participantOffsetTop
-    })
-    return { translate }
+      let top = intersectionTop.value + scrollTop.value;
+      if (
+        intersectionTop.value > INTERSECTION_ERROR_MARGIN &&
+        store?.state.stickyOffset
+      )
+        top += store?.state.stickyOffset;
+      const diagramHeight = store?.state.diagramElement?.clientHeight || 0;
+      const diagramTop = store?.state.diagramElement
+        ? getElementDistanceToTop(store?.state.diagramElement)
+        : 0;
+      if (top <= participantOffsetTop + diagramTop) return 0;
+      return (
+        Math.min(top - diagramTop, diagramHeight - PARTICIPANT_HEIGHT) -
+        participantOffsetTop
+      );
+    });
+    return { translate };
   },
   computed: {
-    ...mapGetters(['participants', 'GroupContext', 'ParticipantContext', 'centerOf']),
+    ...mapGetters([
+      "participants",
+      "GroupContext",
+      "ParticipantContext",
+      "centerOf",
+    ]),
     debug() {
       return !!localStorage.zenumlDebug;
     },
     invisibleStarter() {
-      return this.starterParticipant.name === '_STARTER_';
+      return this.starterParticipant.name === "_STARTER_";
     },
     starterParticipant() {
       return this.participants.Starter();
@@ -98,16 +120,16 @@ export default {
     },
   },
   methods: {
-    ...mapMutations(['increaseGeneration']),
+    ...mapMutations(["increaseGeneration"]),
     getParticipantEntity(ctx) {
       return Participants(ctx).First();
     },
   },
   updated() {
-    logger.debug('LifeLineLayer updated');
+    logger.debug("LifeLineLayer updated");
   },
   mounted() {
-    logger.debug('LifeLineLayer mounted');
+    logger.debug("LifeLineLayer mounted");
   },
   components: {
     LifeLine,

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
@@ -1,19 +1,10 @@
 <template>
   <div
     class="life-line-layer lifeline-layer z-30 absolute h-full flex flex-col top-0"
-    :style="{
-      'min-width': '200px',
-      width: `calc(100% - ${leftGap}px)`,
-      pointerEvents: renderParticipants ? 'none' : 'all',
-    }"
+    :style="{ 'min-width': '200px', 'width': `calc(100% - ${leftGap}px)`, pointerEvents: renderParticipants ? 'none' : 'all' }"
   >
     <!--  header sticky blur effect, DON'T remove, gap + participant height = 72px  -->
-    <div
-      :style="{
-        transform: `translateY(${translate > 0 ? translate - 1 : translate}px)`,
-      }"
-      class="pt-8 after:bg-gradient-to-b after:from-skin-frame after:via-skin-frame after:to-skin-frame/0 after:block after:absolute after:top-0 after:w-full after:h-[72px]"
-    ></div>
+    <div :style="{transform: `translateY(${translate > 0 ? translate - 1 : translate}px)` }" class="pt-8 after:bg-gradient-to-b after:from-skin-frame after:via-skin-frame after:to-skin-frame/0 after:block after:absolute after:top-0 after:w-full after:h-[72px]"></div>
     <div class="container relative grow">
       <life-line
         v-if="starterOnTheLeft"
@@ -46,61 +37,48 @@
   </div>
 </template>
 
+
 <script>
-import parentLogger from "../../../../logger/logger";
-import { GroupContext, ParticipantContext, Participants } from "@/parser";
-import { mapGetters, mapMutations, useStore } from "vuex";
-import LifeLine from "./LifeLine.vue";
-import LifeLineGroup from "./LifeLineGroup.vue";
-const logger = parentLogger.child({ name: "LifeLineLayer" });
+import parentLogger from '../../../../logger/logger';
+import { GroupContext, ParticipantContext, Participants } from '@/parser';
+import {mapGetters, mapMutations, useStore} from 'vuex';
+import LifeLine from './LifeLine.vue';
+import LifeLineGroup from './LifeLineGroup.vue';
+const logger = parentLogger.child({ name: 'LifeLineLayer' });
 
 // TODO: remove the same logic
-const PARTICIPANT_HEIGHT = 70;
-const INTERSECTION_ERROR_MARGIN = 10; // a threshold for judging whether the participant is intersecting with the viewport
-import { computed } from "vue";
+const PARTICIPANT_HEIGHT = 70
+const INTERSECTION_ERROR_MARGIN = 10 // a threshold for judging whether the participant is intersecting with the viewport
+import {computed} from "vue";
 import useIntersectionTop from "@/functions/useIntersectionTop";
 import useDocumentScroll from "@/functions/useDocumentScroll";
-import { getElementDistanceToTop } from "@/utils/dom";
+import {getElementDistanceToTop} from "@/utils/dom";
 
 export default {
-  name: "life-line-layer",
-  props: ["context", "renderParticipants", "leftGap"],
-  setup() {
-    const participantOffsetTop = 0;
-    const store = useStore();
-    const intersectionTop = useIntersectionTop();
-    const [scrollTop] = useDocumentScroll();
+  name: 'life-line-layer',
+  props: ['context', 'renderParticipants', 'leftGap'],
+  setup () {
+    const participantOffsetTop = 0
+    const store = useStore()
+    const intersectionTop = useIntersectionTop()
+    const [scrollTop] = useDocumentScroll()
     const translate = computed(() => {
-      let top = intersectionTop.value + scrollTop.value;
-      if (
-        intersectionTop.value > INTERSECTION_ERROR_MARGIN &&
-        store?.state.stickyOffset
-      )
-        top += store?.state.stickyOffset;
-      const diagramHeight = store?.state.diagramElement?.clientHeight || 0;
-      const diagramTop = store?.state.diagramElement
-        ? getElementDistanceToTop(store?.state.diagramElement)
-        : 0;
-      if (top <= participantOffsetTop + diagramTop) return 0;
-      return (
-        Math.min(top - diagramTop, diagramHeight - PARTICIPANT_HEIGHT) -
-        participantOffsetTop
-      );
-    });
-    return { translate };
+      let top = intersectionTop.value + scrollTop.value
+      if (intersectionTop.value > INTERSECTION_ERROR_MARGIN && store?.state.stickyOffset) top += store?.state.stickyOffset
+      const diagramHeight = store?.state.diagramElement?.clientHeight || 0
+      const diagramTop = store?.state.diagramElement ? getElementDistanceToTop(store?.state.diagramElement) : 0
+      if (top <= participantOffsetTop + diagramTop) return 0
+      return Math.min(top - diagramTop, diagramHeight - PARTICIPANT_HEIGHT) - participantOffsetTop
+    })
+    return { translate }
   },
   computed: {
-    ...mapGetters([
-      "participants",
-      "GroupContext",
-      "ParticipantContext",
-      "centerOf",
-    ]),
+    ...mapGetters(['participants', 'GroupContext', 'ParticipantContext', 'centerOf']),
     debug() {
       return !!localStorage.zenumlDebug;
     },
     invisibleStarter() {
-      return this.starterParticipant.name === "_STARTER_";
+      return this.starterParticipant.name === '_STARTER_';
     },
     starterParticipant() {
       return this.participants.Starter();
@@ -120,16 +98,16 @@ export default {
     },
   },
   methods: {
-    ...mapMutations(["increaseGeneration"]),
+    ...mapMutations(['increaseGeneration']),
     getParticipantEntity(ctx) {
       return Participants(ctx).First();
     },
   },
   updated() {
-    logger.debug("LifeLineLayer updated");
+    logger.debug('LifeLineLayer updated');
   },
   mounted() {
-    logger.debug("LifeLineLayer mounted");
+    logger.debug('LifeLineLayer mounted');
   },
   components: {
     LifeLine,


### PR DESCRIPTION
This PR fixes two issues of zenuml diagrams on mermaid

### Issue 1: Blank screen
Reason: Delay in rendering result
Solution: Introduce isInitialRender to ensure rendering result is returned in initial render

### Issue 2: Blurry mask on top of diagram
Reason: Blurry mask always displayed due to top margin
Solution: Update predicate to prevent mask from showing at diagram edge or container edge


We need to bump the "@mermaid-js/mermaid-zenuml" once this PR is merged.
