### PR TITLE
feat: introduce render mode 

### DIFF
--- a/src/components/DiagramFrame/DiagramFrame.vue
+++ b/src/components/DiagramFrame/DiagramFrame.vue
@@ -94,7 +94,6 @@
           >
         </slot>
       </div>
-
       <width-provider />
     </div>
   </div>

--- a/src/components/DiagramFrame/DiagramFrame.vue
+++ b/src/components/DiagramFrame/DiagramFrame.vue
@@ -49,49 +49,52 @@
       <div
         class="footer text-skin-control px-4 py-1 flex justify-between items-center gap-3"
       >
-        <div class="flex items-center gap-3 color-base">
-          <button
-            class="bottom-1 flex items-center left-1 hide-export"
-            @click="showTipsDialog()"
-          >
-            <Icon name="tip" icon-class="filter grayscale w-4 h-4" />
-          </button>
-          <ThemeSelect v-if="enableMultiTheme" />
-          <div class="flex items-center">
-            <input
-              type="checkbox"
-              id="order-display"
-              class="mr-1"
-              :checked="numbering"
-              @input="toggleNumbering(!numbering)"
-            />
-            <label
-              for="order-display"
-              title="Numbering the diagram"
-              class="select-none"
+        <slot v-if="mode === 'dynamic'">
+          <div class="flex items-center gap-3 color-base">
+            <button
+              class="bottom-1 flex items-center left-1 hide-export"
+              @click="showTipsDialog()"
             >
-              <Icon name="numbering" icon-class="w-6 h-6" />
-            </label>
+              <Icon name="tip" icon-class="filter grayscale w-4 h-4" />
+            </button>
+            <ThemeSelect v-if="enableMultiTheme" />
+            <div class="flex items-center">
+              <input
+                type="checkbox"
+                id="order-display"
+                class="mr-1"
+                :checked="numbering"
+                @input="toggleNumbering(!numbering)"
+              />
+              <label
+                for="order-display"
+                title="Numbering the diagram"
+                class="select-none"
+              >
+                <Icon name="numbering" icon-class="w-6 h-6" />
+              </label>
+            </div>
           </div>
-        </div>
-        <div class="zoom-controls bg-skin-base flex hide-export gap-1">
-          <button class="zoom-in" @click="zoomIn()">
-            <Icon name="zoom-in" icon-class="w-4 h-4" />
-          </button>
-          <label class="w-12 block text-center"
-            >{{ Number(scale * 100).toFixed(0) }}%</label
+          <div class="zoom-controls bg-skin-base flex hide-export gap-1">
+            <button class="zoom-in" @click="zoomIn()">
+              <Icon name="zoom-in" icon-class="w-4 h-4" />
+            </button>
+            <label class="w-12 block text-center"
+              >{{ Number(scale * 100).toFixed(0) }}%</label
+            >
+            <button class="zoom-out" @click="zoomOut()">
+              <Icon name="zoom-out" icon-class="w-4 h-4" />
+            </button>
+          </div>
+          <a
+            target="_blank"
+            href="https://zenuml.com"
+            class="brand text-xs hover:underline"
+            >ZenUML.com</a
           >
-          <button class="zoom-out" @click="zoomOut()">
-            <Icon name="zoom-out" icon-class="w-4 h-4" />
-          </button>
-        </div>
-        <a
-          target="_blank"
-          href="https://zenuml.com"
-          class="brand text-xs hover:underline"
-          >ZenUML.com</a
-        >
+        </slot>
       </div>
+
       <width-provider />
     </div>
   </div>
@@ -118,6 +121,7 @@ export default {
       "theme",
       "numbering",
       "enableMultiTheme",
+      "mode",
     ]),
     ...mapGetters(["rootContext"]),
     title() {

--- a/src/components/DiagramFrame/DiagramFrame.vue
+++ b/src/components/DiagramFrame/DiagramFrame.vue
@@ -49,7 +49,7 @@
       <div
         class="footer text-skin-control px-4 py-1 flex justify-between items-center gap-3"
       >
-        <template v-if="mode === 'dynamic'">
+        <template v-if="mode === RenderMode.Dynamic">
           <div class="flex items-center gap-3 color-base">
             <button
               class="bottom-1 flex items-center left-1 hide-export"
@@ -110,9 +110,15 @@ import * as htmlToImage from "html-to-image";
 import Debug from "./Debug/Debug.vue";
 import ThemeSelect from "./ThemeSelect.vue";
 import Icon from "@/components/Icon/Icon.vue";
+import { RenderMode } from "@/store/Store";
 
 export default {
   name: "DiagramFrame",
+  setup() {
+    return {
+      RenderMode,
+    };
+  },
   computed: {
     ...mapState([
       "showTips",

--- a/src/components/DiagramFrame/DiagramFrame.vue
+++ b/src/components/DiagramFrame/DiagramFrame.vue
@@ -49,7 +49,7 @@
       <div
         class="footer text-skin-control px-4 py-1 flex justify-between items-center gap-3"
       >
-        <slot v-if="mode === 'dynamic'">
+        <template v-if="mode === 'dynamic'">
           <div class="flex items-center gap-3 color-base">
             <button
               class="bottom-1 flex items-center left-1 hide-export"
@@ -92,7 +92,7 @@
             class="brand text-xs hover:underline"
             >ZenUML.com</a
           >
-        </slot>
+        </template>
       </div>
       <width-provider />
     </div>

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLine.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLine.vue
@@ -7,7 +7,7 @@
   >
     <div v-show="debug">{{ centerOf(entity.name) }}</div>
     <participant v-if="renderParticipants" :entity="entity" :offsetTop="top" />
-    <div v-else class="line w0 mx-auto flex-grow w-px"></div>
+    <div v-if="renderLifeLine" class="line w0 mx-auto flex-grow w-px"></div>
   </div>
 </template>
 
@@ -20,7 +20,14 @@ const logger = parentLogger.child({ name: "LifeLine" });
 export default {
   name: "life-line",
   components: { Participant },
-  props: ["entity", "context", "groupLeft", "inGroup", "renderParticipants"],
+  props: [
+    "entity",
+    "context",
+    "groupLeft",
+    "inGroup",
+    "renderParticipants",
+    "renderLifeLine",
+  ],
   data: () => {
     return {
       translateX: 0,

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
@@ -2,7 +2,7 @@
   <div
     class="life-line-layer lifeline-layer z-30 absolute h-full flex flex-col top-0"
     :style="{
-      'min-width': mode === 'dynamic' ? '200px' : 'auto',
+      'min-width': mode === RenderMode.Dynamic ? '200px' : 'auto',
       width: `calc(100% - ${leftGap}px)`,
       pointerEvents: renderParticipants ? 'none' : 'all',
     }"
@@ -64,6 +64,7 @@ import { computed } from "vue";
 import useIntersectionTop from "@/functions/useIntersectionTop";
 import useDocumentScroll from "@/functions/useDocumentScroll";
 import { getElementDistanceToTop } from "@/utils/dom";
+import { RenderMode } from "@/store/Store";
 
 export default {
   name: "life-line-layer",
@@ -73,6 +74,9 @@ export default {
     const store = useStore();
     const intersectionTop = useIntersectionTop();
     const [scrollTop] = useDocumentScroll();
+    if (store.state.mode === RenderMode.static)
+      return { translate: 0, RenderMode };
+
     const translate = computed(() => {
       let top = intersectionTop.value + scrollTop.value;
       if (
@@ -90,7 +94,7 @@ export default {
         participantOffsetTop
       );
     });
-    return { translate };
+    return { translate, RenderMode };
   },
   computed: {
     ...mapGetters([

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
@@ -1,10 +1,19 @@
 <template>
   <div
     class="life-line-layer lifeline-layer z-30 absolute h-full flex flex-col top-0"
-    :style="{ 'min-width': '200px', 'width': `calc(100% - ${leftGap}px)`, pointerEvents: renderParticipants ? 'none' : 'all' }"
+    :style="{
+      'min-width': '200px',
+      width: `calc(100% - ${leftGap}px)`,
+      pointerEvents: renderParticipants ? 'none' : 'all',
+    }"
   >
     <!--  header sticky blur effect, DON'T remove, gap + participant height = 72px  -->
-    <div :style="{transform: `translateY(${translate > 0 ? translate - 1 : translate}px)` }" class="pt-8 after:bg-gradient-to-b after:from-skin-frame after:via-skin-frame after:to-skin-frame/0 after:block after:absolute after:top-0 after:w-full after:h-[72px]"></div>
+    <div
+      :style="{
+        transform: `translateY(${translate > 0 ? translate - 1 : translate}px)`,
+      }"
+      class="pt-8 after:bg-gradient-to-b after:from-skin-frame after:via-skin-frame after:to-skin-frame/0 after:block after:absolute after:top-0 after:w-full after:h-[72px]"
+    ></div>
     <div class="container relative grow">
       <life-line
         v-if="starterOnTheLeft"
@@ -12,6 +21,7 @@
         class="starter"
         :class="{ invisible: invisibleStarter && !debug }"
         :renderParticipants="renderParticipants"
+        :renderLifeLine="renderLifeLine"
       />
       <template v-for="(child, index) in explicitGroupAndParticipants">
         <life-line-group
@@ -25,6 +35,7 @@
           v-if="child instanceof ParticipantContext"
           :entity="getParticipantEntity(child)"
           :renderParticipants="renderParticipants"
+          :renderLifeLine="renderLifeLine"
         />
       </template>
       <life-line
@@ -32,53 +43,67 @@
         :key="entity.name"
         :entity="entity"
         :renderParticipants="renderParticipants"
+        :renderLifeLine="renderLifeLine"
       />
     </div>
   </div>
 </template>
 
-
 <script>
-import parentLogger from '../../../../logger/logger';
-import { GroupContext, ParticipantContext, Participants } from '@/parser';
-import {mapGetters, mapMutations, useStore} from 'vuex';
-import LifeLine from './LifeLine.vue';
-import LifeLineGroup from './LifeLineGroup.vue';
-const logger = parentLogger.child({ name: 'LifeLineLayer' });
+import parentLogger from "../../../../logger/logger";
+import { GroupContext, ParticipantContext, Participants } from "@/parser";
+import { mapGetters, mapMutations, useStore } from "vuex";
+import LifeLine from "./LifeLine.vue";
+import LifeLineGroup from "./LifeLineGroup.vue";
+const logger = parentLogger.child({ name: "LifeLineLayer" });
 
 // TODO: remove the same logic
-const PARTICIPANT_HEIGHT = 70
-const INTERSECTION_ERROR_MARGIN = 10 // a threshold for judging whether the participant is intersecting with the viewport
-import {computed} from "vue";
+const PARTICIPANT_HEIGHT = 70;
+const INTERSECTION_ERROR_MARGIN = 10; // a threshold for judging whether the participant is intersecting with the viewport
+import { computed } from "vue";
 import useIntersectionTop from "@/functions/useIntersectionTop";
 import useDocumentScroll from "@/functions/useDocumentScroll";
-import {getElementDistanceToTop} from "@/utils/dom";
+import { getElementDistanceToTop } from "@/utils/dom";
 
 export default {
-  name: 'life-line-layer',
-  props: ['context', 'renderParticipants', 'leftGap'],
-  setup () {
-    const participantOffsetTop = 0
-    const store = useStore()
-    const intersectionTop = useIntersectionTop()
-    const [scrollTop] = useDocumentScroll()
+  name: "life-line-layer",
+  props: ["context", "renderParticipants", "renderLifeLine", "leftGap"],
+  setup() {
+    const participantOffsetTop = 0;
+    const store = useStore();
+    const intersectionTop = useIntersectionTop();
+    const [scrollTop] = useDocumentScroll();
     const translate = computed(() => {
-      let top = intersectionTop.value + scrollTop.value
-      if (intersectionTop.value > INTERSECTION_ERROR_MARGIN && store?.state.stickyOffset) top += store?.state.stickyOffset
-      const diagramHeight = store?.state.diagramElement?.clientHeight || 0
-      const diagramTop = store?.state.diagramElement ? getElementDistanceToTop(store?.state.diagramElement) : 0
-      if (top <= participantOffsetTop + diagramTop) return 0
-      return Math.min(top - diagramTop, diagramHeight - PARTICIPANT_HEIGHT) - participantOffsetTop
-    })
-    return { translate }
+      let top = intersectionTop.value + scrollTop.value;
+      if (
+        intersectionTop.value > INTERSECTION_ERROR_MARGIN &&
+        store?.state.stickyOffset
+      )
+        top += store?.state.stickyOffset;
+      const diagramHeight = store?.state.diagramElement?.clientHeight || 0;
+      const diagramTop = store?.state.diagramElement
+        ? getElementDistanceToTop(store?.state.diagramElement)
+        : 0;
+      if (top <= participantOffsetTop + diagramTop) return 0;
+      return (
+        Math.min(top - diagramTop, diagramHeight - PARTICIPANT_HEIGHT) -
+        participantOffsetTop
+      );
+    });
+    return { translate };
   },
   computed: {
-    ...mapGetters(['participants', 'GroupContext', 'ParticipantContext', 'centerOf']),
+    ...mapGetters([
+      "participants",
+      "GroupContext",
+      "ParticipantContext",
+      "centerOf",
+    ]),
     debug() {
       return !!localStorage.zenumlDebug;
     },
     invisibleStarter() {
-      return this.starterParticipant.name === '_STARTER_';
+      return this.starterParticipant.name === "_STARTER_";
     },
     starterParticipant() {
       return this.participants.Starter();
@@ -98,16 +123,16 @@ export default {
     },
   },
   methods: {
-    ...mapMutations(['increaseGeneration']),
+    ...mapMutations(["increaseGeneration"]),
     getParticipantEntity(ctx) {
       return Participants(ctx).First();
     },
   },
   updated() {
-    logger.debug('LifeLineLayer updated');
+    logger.debug("LifeLineLayer updated");
   },
   mounted() {
-    logger.debug('LifeLineLayer mounted');
+    logger.debug("LifeLineLayer mounted");
   },
   components: {
     LifeLine,

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
@@ -2,7 +2,7 @@
   <div
     class="life-line-layer lifeline-layer z-30 absolute h-full flex flex-col top-0"
     :style="{
-      'min-width': '200px',
+      'min-width': mode === 'dynamic' ? '200px' : 'auto',
       width: `calc(100% - ${leftGap}px)`,
       pointerEvents: renderParticipants ? 'none' : 'all',
     }"

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.vue
@@ -3,7 +3,11 @@
     class="participant bg-skin-participant shadow-participant border-skin-participant text-skin-participant rounded text-base leading-4 flex flex-col justify-center z-10 h-10 top-8"
     :class="{ selected: selected }"
     ref="participant"
-    :style="{ backgroundColor: backgroundColor, color: color, transform: `translateY(${translate}px)` }"
+    :style="{
+      backgroundColor: backgroundColor,
+      color: color,
+      transform: `translateY(${translate}px)`,
+    }"
     @click="onSelect"
   >
     <!-- Set the background and text color with bg-skin-base and text-skin-base.
@@ -24,48 +28,64 @@
       >
         {{ comment }}
       </span>
-      <label class="interface leading-4" v-if="stereotype">«{{ stereotype }}»</label>
+      <label class="interface leading-4" v-if="stereotype"
+        >«{{ stereotype }}»</label
+      >
       <label class="name leading-4">{{ entity.label || entity.name }}</label>
     </div>
   </div>
 </template>
 
 <script>
-import { brightnessIgnoreAlpha, removeAlpha } from '@/utils/Color';
-import iconPath from '../../Tutorial/Icons';
-import { computed, ref } from 'vue';
-import useDocumentScroll from '@/functions/useDocumentScroll';
-import useIntersectionTop from '@/functions/useIntersectionTop';
-import { useStore } from 'vuex';
-import { getElementDistanceToTop } from '@/utils/dom';
-import { PARTICIPANT_HEIGHT } from '@/positioning/Constants';
+import { brightnessIgnoreAlpha, removeAlpha } from "@/utils/Color";
+import iconPath from "../../Tutorial/Icons";
+import { computed, ref } from "vue";
+import useDocumentScroll from "@/functions/useDocumentScroll";
+import useIntersectionTop from "@/functions/useIntersectionTop";
+import { useStore } from "vuex";
+import { getElementDistanceToTop } from "@/utils/dom";
+import { PARTICIPANT_HEIGHT } from "@/positioning/Constants";
 
-const INTERSECTION_ERROR_MARGIN = 10 // a threshold for judging whether the participant is intersecting with the viewport
+const INTERSECTION_ERROR_MARGIN = 10; // a threshold for judging whether the participant is intersecting with the viewport
 
 export default {
-  name: 'Participant',
+  name: "Participant",
   setup(props) {
-    const store = useStore()
-    const participant = ref(null)
-    const intersectionTop = useIntersectionTop()
-    const [scrollTop] = useDocumentScroll()
+    const store = useStore();
+    const participant = ref(null);
+    if (store.state.mode === "static") return { translate: 0, participant };
+
+    const intersectionTop = useIntersectionTop();
+    const [scrollTop] = useDocumentScroll();
     const translate = computed(() => {
-      const participantOffsetTop = props.offsetTop || 0
-      let top = intersectionTop.value + scrollTop.value
-      if (intersectionTop.value > INTERSECTION_ERROR_MARGIN && store?.state.stickyOffset) top += store?.state.stickyOffset
-      const diagramHeight = store?.state.diagramElement?.clientHeight || 0
-      const diagramTop = store?.state.diagramElement ? getElementDistanceToTop(store?.state.diagramElement) : 0
-      if (top < participantOffsetTop + diagramTop) return 0
-      return Math.min(top - diagramTop, diagramHeight - PARTICIPANT_HEIGHT) - participantOffsetTop
-    })
-    return { translate, participant }
+      const participantOffsetTop = props.offsetTop || 0;
+      let top = intersectionTop.value + scrollTop.value;
+      if (
+        intersectionTop.value > INTERSECTION_ERROR_MARGIN &&
+        store?.state.stickyOffset
+      )
+        top += store?.state.stickyOffset;
+      const diagramHeight = store?.state.diagramElement?.clientHeight || 0;
+      const diagramTop = store?.state.diagramElement
+        ? getElementDistanceToTop(store?.state.diagramElement)
+        : 0;
+      if (top < participantOffsetTop + diagramTop) return 0;
+      return (
+        Math.min(top - diagramTop, diagramHeight - PARTICIPANT_HEIGHT) -
+        participantOffsetTop
+      );
+    });
+    return { translate, participant };
   },
   props: {
     entity: {
       type: Object,
       required: true,
     },
-    offsetTop: 0
+    offsetTop: {
+      type: Number,
+      default: 0,
+    },
   },
   data() {
     return {
@@ -112,7 +132,7 @@ export default {
   },
   methods: {
     onSelect() {
-      this.$store.commit('onSelect', this.entity.name);
+      this.$store.commit("onSelect", this.entity.name);
     },
     updateFontColor() {
       // Returning `undefined` so that background-color is not set at all in the style attribute
@@ -121,12 +141,12 @@ export default {
       }
       let bgColor = window
         .getComputedStyle(this.$refs.participant)
-        .getPropertyValue('background-color');
+        .getPropertyValue("background-color");
       if (!bgColor) {
         return undefined;
       }
       let b = brightnessIgnoreAlpha(bgColor);
-      this.color = b > 128 ? '#000' : '#fff';
+      this.color = b > 128 ? "#000" : "#fff";
     },
   },
 };

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.vue
@@ -45,6 +45,7 @@ import useIntersectionTop from "@/functions/useIntersectionTop";
 import { useStore } from "vuex";
 import { getElementDistanceToTop } from "@/utils/dom";
 import { PARTICIPANT_HEIGHT } from "@/positioning/Constants";
+import { RenderMode } from "@/store/Store";
 
 const INTERSECTION_ERROR_MARGIN = 10; // a threshold for judging whether the participant is intersecting with the viewport
 
@@ -53,7 +54,9 @@ export default {
   setup(props) {
     const store = useStore();
     const participant = ref(null);
-    if (store.state.mode === "static") return { translate: 0, participant };
+    if (store.state.mode === RenderMode.Static) {
+      return { translate: 0, participant };
+    }
 
     const intersectionTop = useIntersectionTop();
     const [scrollTop] = useDocumentScroll();

--- a/src/components/DiagramFrame/SeqDiagram/SeqDiagram.vue
+++ b/src/components/DiagramFrame/SeqDiagram/SeqDiagram.vue
@@ -7,7 +7,7 @@
          .bg-skin-base is repeated because .zenuml reset it to default theme.
      -->
     <div :style="{ paddingLeft: `${paddingLeft}px` }" class="relative">
-      <template v-if="mode === 'dynamic'">
+      <template v-if="mode === RenderMode.Dynamic">
         <life-line-layer
           :leftGap="paddingLeft"
           :context="rootContext.head()"
@@ -25,7 +25,7 @@
           :renderLifeLine="false"
         />
       </template>
-      <template v-if="mode === 'static'">
+      <template v-if="mode === RenderMode.Static">
         <life-line-layer
           :leftGap="paddingLeft"
           :context="rootContext.head()"
@@ -50,6 +50,7 @@ import FrameBuilder from "@/parser/FrameBuilder";
 import FrameBorder from "@/positioning/FrameBorder";
 import { TotalWidth } from "@/components/DiagramFrame/SeqDiagram/WidthOfContext";
 import { MARGIN } from "@/positioning/Constants";
+import { RenderMode } from "@/store/Store";
 
 const store = useStore();
 const mode = computed(() => store.state.mode);

--- a/src/components/DiagramFrame/SeqDiagram/SeqDiagram.vue
+++ b/src/components/DiagramFrame/SeqDiagram/SeqDiagram.vue
@@ -7,20 +7,36 @@
          .bg-skin-base is repeated because .zenuml reset it to default theme.
      -->
     <div :style="{ paddingLeft: `${paddingLeft}px` }" class="relative">
-      <life-line-layer
-        :leftGap="paddingLeft"
-        :context="rootContext.head()"
-        :renderParticipants="false"
-      />
-      <message-layer
-        :context="rootContext.block()"
-        :style="{ width: `${width}px` }"
-      />
-      <life-line-layer
-        :leftGap="paddingLeft"
-        :context="rootContext.head()"
-        :renderParticipants="true"
-      />
+      <slot v-if="mode === 'dynamic'">
+        <life-line-layer
+          :leftGap="paddingLeft"
+          :context="rootContext.head()"
+          :renderParticipants="false"
+          :renderLifeLine="true"
+        />
+        <message-layer
+          :context="rootContext.block()"
+          :style="{ width: `${width}px` }"
+        />
+        <life-line-layer
+          :leftGap="paddingLeft"
+          :context="rootContext.head()"
+          :renderParticipants="true"
+          :renderLifeLine="false"
+        />
+      </slot>
+      <slot v-if="mode === 'static'">
+        <life-line-layer
+          :leftGap="paddingLeft"
+          :context="rootContext.head()"
+          :renderParticipants="true"
+          :renderLifeLine="true"
+        />
+        <message-layer
+          :context="rootContext.block()"
+          :style="{ width: `${width}px` }"
+        />
+      </slot>
     </div>
   </div>
 </template>
@@ -36,6 +52,7 @@ import { TotalWidth } from "@/components/DiagramFrame/SeqDiagram/WidthOfContext"
 import { MARGIN } from "@/positioning/Constants";
 
 const store = useStore();
+const mode = computed(() => store.state.mode);
 const rootContext = computed(() => store.getters.rootContext);
 const coordinates = computed(() => store.getters.coordinates);
 const width = computed(() => TotalWidth(rootContext.value, coordinates.value));

--- a/src/components/DiagramFrame/SeqDiagram/SeqDiagram.vue
+++ b/src/components/DiagramFrame/SeqDiagram/SeqDiagram.vue
@@ -7,7 +7,7 @@
          .bg-skin-base is repeated because .zenuml reset it to default theme.
      -->
     <div :style="{ paddingLeft: `${paddingLeft}px` }" class="relative">
-      <slot v-if="mode === 'dynamic'">
+      <template v-if="mode === 'dynamic'">
         <life-line-layer
           :leftGap="paddingLeft"
           :context="rootContext.head()"
@@ -24,8 +24,8 @@
           :renderParticipants="true"
           :renderLifeLine="false"
         />
-      </slot>
-      <slot v-if="mode === 'static'">
+      </template>
+      <template v-if="mode === 'static'">
         <life-line-layer
           :leftGap="paddingLeft"
           :context="rootContext.head()"
@@ -36,7 +36,7 @@
           :context="rootContext.block()"
           :style="{ width: `${width}px` }"
         />
-      </slot>
+      </template>
     </div>
   </div>
 </template>

--- a/src/core.ts
+++ b/src/core.ts
@@ -81,7 +81,7 @@ export default class ZenUml implements IZenUml {
     this._theme = config?.theme || this._theme;
     this.store.state.stickyOffset = config?.stickyOffset || 0;
     this.store.state.theme = this._theme || "default";
-    this.store.state.mode = config?.mode || "dynamic";
+    this.store.state.mode = config?.mode || RenderMode.Dynamic;
 
     // this.initialRender is used to avoid the first rendering is debounced by setTimeout.
     // The first rendering should be executed immediately. It fixes the issue that causes the blank screen on mermaid live editor.

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,7 @@
 import parentLogger from "./logger/logger";
 import { createApp } from "vue";
 import { createStore } from "vuex";
-import Store, { VisualizationMode } from "./store/Store";
+import Store, { RenderMode } from "./store/Store";
 import DiagramFrame from "./components/DiagramFrame/DiagramFrame.vue";
 import SeqDiagram from "./components/DiagramFrame/SeqDiagram/SeqDiagram.vue";
 
@@ -25,7 +25,7 @@ interface Config {
   enableMultiTheme?: boolean;
   stickyOffset?: number;
   onContentChange?: (code: string) => void;
-  mode?: VisualizationMode;
+  mode?: RenderMode;
 }
 interface IZenUml {
   get code(): string | undefined;

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,7 @@
 import parentLogger from "./logger/logger";
 import { createApp } from "vue";
 import { createStore } from "vuex";
-import Store from "./store/Store";
+import Store, { VisualizationMode } from "./store/Store";
 import DiagramFrame from "./components/DiagramFrame/DiagramFrame.vue";
 import SeqDiagram from "./components/DiagramFrame/SeqDiagram/SeqDiagram.vue";
 
@@ -25,6 +25,7 @@ interface Config {
   enableMultiTheme: boolean;
   stickyOffset?: number;
   onContentChange?: (code: string) => void;
+  mode: VisualizationMode;
 }
 interface IZenUml {
   get code(): string | undefined;
@@ -80,6 +81,7 @@ export default class ZenUml implements IZenUml {
     this._theme = config?.theme || this._theme;
     this.store.state.stickyOffset = config?.stickyOffset || 0;
     this.store.state.theme = this._theme || "default";
+    this.store.state.mode = config?.mode || "static";
 
     // this.initialRender is used to avoid the first rendering is debounced by setTimeout.
     // The first rendering should be executed immediately. It fixes the issue that causes the blank screen on mermaid live editor.

--- a/src/core.ts
+++ b/src/core.ts
@@ -22,10 +22,10 @@ const logger = parentLogger.child({ name: "core" });
 
 interface Config {
   theme?: string;
-  enableMultiTheme: boolean;
+  enableMultiTheme?: boolean;
   stickyOffset?: number;
   onContentChange?: (code: string) => void;
-  mode: VisualizationMode;
+  mode?: VisualizationMode;
 }
 interface IZenUml {
   get code(): string | undefined;
@@ -81,7 +81,7 @@ export default class ZenUml implements IZenUml {
     this._theme = config?.theme || this._theme;
     this.store.state.stickyOffset = config?.stickyOffset || 0;
     this.store.state.theme = this._theme || "default";
-    this.store.state.mode = config?.mode || "static";
+    this.store.state.mode = config?.mode || "dynamic";
 
     // this.initialRender is used to avoid the first rendering is debounced by setTimeout.
     // The first rendering should be executed immediately. It fixes the issue that causes the blank screen on mermaid live editor.

--- a/src/functions/useIntersectionTop.ts
+++ b/src/functions/useIntersectionTop.ts
@@ -1,61 +1,83 @@
 import { onMounted, onUnmounted, ref } from "vue";
 
 const DETECTOR_COUNT = 10;
-const INTERSECTION_ERROR_MARGIN = 1
+const INTERSECTION_ERROR_MARGIN = 1;
 
-const detectorContainer = document.createElement("div");
-Object.assign(detectorContainer.style, {
-  position: "absolute",
-  top: "0",
-  left: "0",
-  opacity: "0",
-  pointerEvents: "none"
-});
-const detectors = new Array(DETECTOR_COUNT).fill(0).map(() => {
-  const detector = document.createElement("div");
-  Object.assign(detector.style, {
+function initializeDetectors() {
+  let detectorContainer = document.getElementById(
+    "zenuml-intersection-detector-container",
+  );
+  let detectors = Array.from(
+    document.getElementsByClassName("zenuml-intersection-detector"),
+  );
+
+  if (detectorContainer && detectors.length === DETECTOR_COUNT) {
+    return { detectorContainer, detectors };
+  }
+
+  detectorContainer = document.createElement("div");
+  detectorContainer.id = "zenuml-intersection-detector-container";
+
+  Object.assign(detectorContainer.style, {
     position: "absolute",
     top: "0",
     left: "0",
-    width: "100%"
+    opacity: "0",
+    pointerEvents: "none",
   });
-  detectorContainer.appendChild(detector);
-  return detector;
-});
-document.body.appendChild(detectorContainer);
+
+  detectors = new Array(DETECTOR_COUNT).fill(0).map(() => {
+    const detector = document.createElement("div");
+    detector.className = "zenuml-intersection-detector";
+    Object.assign(detector.style, {
+      position: "absolute",
+      top: "0",
+      left: "0",
+      width: "100%",
+    });
+    detectorContainer.appendChild(detector);
+    return detector;
+  });
+  document.body.appendChild(detectorContainer);
+
+  return { detectorContainer, detectors };
+}
 
 export default function useIntersectionTop() {
   const top = ref(0);
   let observer: IntersectionObserver;
 
   onMounted(() => {
+    const { detectorContainer, detectors } = initializeDetectors();
+
     const scrollHeight = document.documentElement.scrollHeight;
     const scrollWidth = document.documentElement.scrollWidth;
     detectorContainer.style.height = scrollHeight + "px";
     detectorContainer.style.width = scrollWidth + "px";
     const detectorHeight = Math.ceil(
-      document.documentElement.scrollHeight / DETECTOR_COUNT
+      document.documentElement.scrollHeight / DETECTOR_COUNT,
     );
     const threshold = [...Array(detectorHeight + 1).keys()].map(
-      i => i / detectorHeight
+      (i) => i / detectorHeight,
     );
     detectors.forEach((detector, index) => {
-      detector.style.top = index * detectorHeight + "px";
-      detector.style.height = detectorHeight + "px";
+      (detector as HTMLElement).style.top = index * detectorHeight + "px";
+      (detector as HTMLElement).style.height = detectorHeight + "px";
     });
     observer = new IntersectionObserver(
       ([entry]) => {
         const isTopIntersection =
-          entry.intersectionRect.top - entry.boundingClientRect.top > INTERSECTION_ERROR_MARGIN || entry.target === detectors[0];
-          if (isTopIntersection) {
-            top.value = entry.intersectionRect.top;
-          }
+          entry.intersectionRect.top - entry.boundingClientRect.top >
+            INTERSECTION_ERROR_MARGIN || entry.target === detectors[0];
+        if (isTopIntersection) {
+          top.value = entry.intersectionRect.top;
+        }
       },
       {
-        threshold
-      }
+        threshold,
+      },
     );
-    detectors.forEach(detector => {
+    detectors.forEach((detector) => {
       observer.observe(detector);
     });
   });

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -27,7 +27,7 @@ export interface Warning {
 
 /*
  * RenderMode
- * Static: Render once and never update, also disable sticky participants and hide the footer
+ * Static: Compatible with Mermaid renderind which renders once and never update. It also disables sticky participants and hides the footer
  * Dynamic: Render once and update when code changes
  */
 export const enum RenderMode {

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -25,7 +25,7 @@ export interface Warning {
   message: string;
 }
 
-export type VisualizationMode = "static" | "dynamic";
+export type RenderMode = "static" | "dynamic";
 
 export interface StoreState {
   warning: Warning | undefined;
@@ -33,7 +33,7 @@ export interface StoreState {
   scale: number;
   selected: any[];
   cursor: any;
-  mode: VisualizationMode;
+  mode: RenderMode;
   showTips: boolean;
   onElementClick: (codeRange: CodeRange) => void;
   numbering: boolean;

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -25,7 +25,15 @@ export interface Warning {
   message: string;
 }
 
-export type RenderMode = "static" | "dynamic";
+/*
+ * RenderMode
+ * Static: Render once and never update, also disable sticky participants and hide the footer
+ * Dynamic: Render once and update when code changes
+ */
+export const enum RenderMode {
+  Static = "static",
+  Dynamic = "dynamic",
+}
 
 export interface StoreState {
   warning: Warning | undefined;
@@ -54,7 +62,7 @@ const Store = (): StoreOptions<StoreState> => {
       selected: [],
       cursor: null,
       showTips: false,
-      mode: "dynamic",
+      mode: RenderMode.Dynamic,
       numbering: Boolean(
         localStorage.getItem(`${location.hostname}-zenuml-numbering`),
       ),

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -25,12 +25,15 @@ export interface Warning {
   message: string;
 }
 
+export type VisualizationMode = "static" | "dynamic";
+
 export interface StoreState {
   warning: Warning | undefined;
   code: string;
   scale: number;
   selected: any[];
   cursor: any;
+  mode: VisualizationMode;
   showTips: boolean;
   onElementClick: (codeRange: CodeRange) => void;
   numbering: boolean;
@@ -51,6 +54,7 @@ const Store = (): StoreOptions<StoreState> => {
       selected: [],
       cursor: null,
       showTips: false,
+      mode: "dynamic",
       numbering: Boolean(
         localStorage.getItem(`${location.hostname}-zenuml-numbering`),
       ),


### PR DESCRIPTION
ZenUML diagrams do not render properly in Mermaid due to differences in rendering mechanisms between the two frameworks. Mermaid only displays the initial render result of ZenUML and ignores subsequent renders. It incurs a few issues including the footer icons being invisible, sticky top participants not functional.

To tackle this problem, **the render mode** is introduced. By default, ZenUML uses the `dynamic` mode, which keeps all existing features intact. In the `static` mode, some changes are made to resolve the issues occurring in Mermaid.

### Changes
1. Add `mode` field to `Config` and `Store`. Set `mode` to `dynamic` by default.
2. Add an additional property `renderLifeLine` to control the display of life line elements. 
3. Render participants and life lines in one `life-life-layer` in `static` mode.
4. Hide footer in `static` mode.
5. Lazy initialize intersection detectors when `useIntersectionTop` function is called; in this case, the detectors will not get created in `static` mode.

### Rendered in Mermaid
Before:
![image](https://github.com/mermaid-js/zenuml-core/assets/3481791/d18c09fc-b732-4390-9bec-9b56b1fcaf75)

After:
![image](https://github.com/mermaid-js/zenuml-core/assets/3481791/b964cee5-8aea-4130-bf00-a33a2019bd44)

