### PR TITLE
#112 Add feature for editable alt condition

### DIFF
--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
@@ -73,7 +73,9 @@ export default {
     const participantOffsetTop = 0;
     const store = useStore();
     const mode = computed(() => store.state.mode);
-    if (mode.value === RenderMode.static) return { translate: 0, RenderMode };
+    if (mode.value === RenderMode.static)
+      return { translate: 0, RenderMode, mode };
+
     const intersectionTop = useIntersectionTop();
     const [scrollTop] = useDocumentScroll();
 

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
@@ -72,10 +72,10 @@ export default {
   setup() {
     const participantOffsetTop = 0;
     const store = useStore();
-    const intersectionTop = useIntersectionTop();
-    const [scrollTop] = useDocumentScroll();
     const mode = computed(() => store.state.mode);
     if (mode.value === RenderMode.static) return { translate: 0, RenderMode };
+    const intersectionTop = useIntersectionTop();
+    const [scrollTop] = useDocumentScroll();
 
     const translate = computed(() => {
       let top = intersectionTop.value + scrollTop.value;

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/LifeLineLayer.vue
@@ -74,8 +74,8 @@ export default {
     const store = useStore();
     const intersectionTop = useIntersectionTop();
     const [scrollTop] = useDocumentScroll();
-    if (store.state.mode === RenderMode.static)
-      return { translate: 0, RenderMode };
+    const mode = computed(() => store.state.mode);
+    if (mode.value === RenderMode.static) return { translate: 0, RenderMode };
 
     const translate = computed(() => {
       let top = intersectionTop.value + scrollTop.value;
@@ -94,7 +94,7 @@ export default {
         participantOffsetTop
       );
     });
-    return { translate, RenderMode };
+    return { translate, RenderMode, mode };
   },
   computed: {
     ...mapGetters([

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/EditableLabel.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/EditableLabel.vue
@@ -1,0 +1,124 @@
+<template>
+  <label
+    class="condition px-1"
+    :class="{
+      editable: editable,
+    }"
+    :contenteditable="editable"
+    @dblclick="handleDblClick"
+    @blur="handleBlur"
+    @keyup="handleKeyup"
+    @keydown="handleKeydown"
+  >
+    {{ editable ? conditionText : `[${conditionText}]` }}
+  </label>
+</template>
+<script>
+import { computed, nextTick } from "vue";
+import { useStore } from "vuex";
+
+export default {
+  name: "EditableLabel",
+  props: ["editable", "block", "toggleEditable", "getConditionFromBlock"],
+  setup(props) {
+    const store = useStore();
+    const code = computed(() => store.getters.code);
+    const onContentChange = computed(
+      () => store.getters.onContentChange || (() => {}),
+    );
+    const condition = computed(() => props.getConditionFromBlock(props.block));
+    const conditionText = computed(
+      () => condition.value.getFormattedText() ?? "",
+    );
+
+    function updateCode(code) {
+      store.dispatch("updateCode", { code });
+      onContentChange.value(code);
+    }
+
+    async function handleDblClick(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      props.toggleEditable(true);
+
+      await nextTick();
+      const range = document.createRange();
+
+      // select the text and set the cursor at the end
+      range.selectNodeContents(e.target);
+      range.collapse(false);
+      const sel = window.getSelection();
+      if (!sel) return;
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+    }
+
+    async function handleBlur(e) {
+      // avoid race condition with keyup event
+      await nextTick();
+      if (!props.editable) return;
+      replaceConditionText(e);
+    }
+
+    function handleKeydown(e) {
+      // prevent new line
+      if (e.key === "Enter") {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    }
+
+    function handleKeyup(e) {
+      if (e.key === "Enter" || e.key === "Escape" || e.key === "Tab") {
+        replaceConditionText(e);
+      }
+    }
+
+    function replaceConditionText(e) {
+      props.toggleEditable(false);
+      e.preventDefault();
+      e.stopPropagation();
+
+      const target = e.target;
+      if (!(target instanceof HTMLElement)) return;
+      let newText = target.innerText.trim() ?? "";
+
+      // if text is empty, we need to replace it with the original condition text
+      if (newText === "") {
+        target.innerText = conditionText.value;
+        return;
+      }
+
+      // if text has empty spaces, we need to wrap it with double quotes
+      if (newText.includes(" ")) {
+        newText = newText.replace(/"/g, "");
+        newText = `"${newText}"`;
+      }
+
+      const [start, end] = [
+        condition.value.start?.start,
+        condition.value.stop?.stop,
+      ];
+      updateCode(
+        code.value.slice(0, start) + newText + code.value.slice(end + 1),
+      );
+    }
+
+    return {
+      conditionText,
+      handleBlur,
+      handleDblClick,
+      handleKeydown,
+      handleKeyup,
+    };
+  },
+};
+</script>
+
+<style scoped>
+.condition.editable {
+  padding: 2px 6px;
+  margin-left: 4px;
+  cursor: text;
+}
+</style>

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/ConditionLabel.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/ConditionLabel.vue
@@ -29,7 +29,7 @@ export default {
     );
     const condition = computed(() => props.getConditionFromBlock(props.block));
     const conditionText = computed(
-      () => condition.value.getFormattedText() ?? "",
+      () => condition?.value?.getFormattedText() ?? "",
     );
 
     function toggleEditable(_editable) {
@@ -79,6 +79,11 @@ export default {
       }
     }
 
+    function checkSpecialCharacters(text) {
+      const regex = /[!@#$%^&*()+-,.?''":{}|<>/\s]/g;
+      return regex.test(text);
+    }
+
     function replaceConditionText(e) {
       toggleEditable(false);
       e.preventDefault();
@@ -94,9 +99,9 @@ export default {
         return;
       }
 
-      // if text has empty spaces, we need to wrap it with double quotes
-      if (newText.includes(" ")) {
-        newText = newText.replace(/"/g, "");
+      // if text has special characters, we need to wrap it with double quotes
+      if (checkSpecialCharacters(newText)) {
+        newText = newText.replace(/"/g, ""); // remove existing double quotes
         newText = `"${newText}"`;
       }
 

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/ConditionLabel.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/ConditionLabel.vue
@@ -1,6 +1,7 @@
 <template>
   <label
-    class="condition px-1"
+    title="Double click to edit"
+    class="condition px-1 cursor-text hover:text-skin-message-hover hover:bg-skin-message-hover"
     :class="{
       'py-1 px-2 ml-1 cursor-text': editable,
     }"

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/ConditionLabel.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/ConditionLabel.vue
@@ -14,13 +14,14 @@
   </label>
 </template>
 <script>
-import { computed, nextTick } from "vue";
+import { computed, nextTick, ref } from "vue";
 import { useStore } from "vuex";
 
 export default {
-  name: "EditableLabel",
-  props: ["editable", "block", "toggleEditable", "getConditionFromBlock"],
+  name: "ConditionLabel",
+  props: ["block", "getConditionFromBlock"],
   setup(props) {
+    const editable = ref(false);
     const store = useStore();
     const code = computed(() => store.getters.code);
     const onContentChange = computed(
@@ -31,6 +32,10 @@ export default {
       () => condition.value.getFormattedText() ?? "",
     );
 
+    function toggleEditable(_editable) {
+      editable.value = _editable;
+    }
+
     function updateCode(code) {
       store.dispatch("updateCode", { code });
       onContentChange.value(code);
@@ -39,7 +44,7 @@ export default {
     async function handleDblClick(e) {
       e.preventDefault();
       e.stopPropagation();
-      props.toggleEditable(true);
+      toggleEditable(true);
 
       await nextTick();
       const range = document.createRange();
@@ -56,7 +61,7 @@ export default {
     async function handleBlur(e) {
       // avoid race condition with keyup event
       await nextTick();
-      if (!props.editable) return;
+      if (!editable.value) return;
       replaceConditionText(e);
     }
 
@@ -75,7 +80,7 @@ export default {
     }
 
     function replaceConditionText(e) {
-      props.toggleEditable(false);
+      toggleEditable(false);
       e.preventDefault();
       e.stopPropagation();
 
@@ -96,8 +101,8 @@ export default {
       }
 
       const [start, end] = [
-        condition.value.start?.start,
-        condition.value.stop?.stop,
+        condition.value?.start?.start,
+        condition.value?.stop?.stop,
       ];
       updateCode(
         code.value.slice(0, start) + newText + code.value.slice(end + 1),
@@ -105,6 +110,7 @@ export default {
     }
 
     return {
+      editable,
       conditionText,
       handleBlur,
       handleDblClick,

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/ConditionLabel.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/ConditionLabel.vue
@@ -2,7 +2,7 @@
   <label
     class="condition px-1"
     :class="{
-      editable: editable,
+      'py-1 px-2 ml-1 cursor-text': editable,
     }"
     :contenteditable="editable"
     @dblclick="handleDblClick"
@@ -32,7 +32,7 @@ export default {
       () => condition?.value?.getFormattedText() ?? "",
     );
 
-    function toggleEditable(_editable) {
+    function setEditable(_editable) {
       editable.value = _editable;
     }
 
@@ -44,7 +44,7 @@ export default {
     async function handleDblClick(e) {
       e.preventDefault();
       e.stopPropagation();
-      toggleEditable(true);
+      setEditable(true);
 
       await nextTick();
       const range = document.createRange();
@@ -85,7 +85,7 @@ export default {
     }
 
     function replaceConditionText(e) {
-      toggleEditable(false);
+      setEditable(false);
       e.preventDefault();
       e.stopPropagation();
 
@@ -126,10 +126,4 @@ export default {
 };
 </script>
 
-<style scoped>
-.condition.editable {
-  padding: 2px 6px;
-  margin-left: 4px;
-  cursor: text;
-}
-</style>
+<style scoped></style>

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentAlt.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentAlt.vue
@@ -28,9 +28,7 @@
     <div :class="{ hidden: collapsed }">
       <div class="segment">
         <div class="text-skin-fragment flex">
-          <EditableLabel
-            :editable="editableMap.get(ifBlock)"
-            :toggleEditable="(bool) => toggleEditable(ifBlock, bool)"
+          <ConditionLabel
             :block="ifBlock"
             :getConditionFromBlock="conditionFromIfElseBlock"
           />
@@ -49,8 +47,6 @@
           <div class="text-skin-fragment" :key="index + 1000">
             <label class="else-if hidden">else if</label>
             <EditableLabel
-              :editable="editableMap.get(elseIfBlock)"
-              :toggleEditable="(bool) => toggleEditable(elseIfBlock, bool)"
               :block="elseIfBlock"
               :getConditionFromBlock="conditionFromIfElseBlock"
             />
@@ -86,22 +82,21 @@
 </template>
 
 <script>
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useStore } from "vuex";
 import fragment from "./FragmentMixin";
 import { increaseNumber, blockLength } from "@/utils/Numbering";
-import EditableLabel from "../../EditableLabel.vue";
+import ConditionLabel from "./ConditionLabel.vue";
 
 export default {
   name: "fragment-alt",
   props: ["context", "comment", "selfCallIndent", "commentObj", "number"],
   mixins: [fragment],
   components: {
-    EditableLabel,
+    ConditionLabel,
   },
   setup(props) {
     const store = useStore();
-    const editableMap = ref(new Map());
     const numbering = computed(() => store.state.numbering);
     const from = computed(() => props.context.Origin());
     const alt = computed(() => props.context.alt());
@@ -125,14 +120,6 @@ export default {
       return acc;
     });
 
-    // initialize editableMap
-    editableMap.value.set(ifBlock.value, false);
-    if (elseIfBlocks.value.length > 0) {
-      elseIfBlocks.value.forEach((block) => {
-        editableMap.value.set(block, false);
-      });
-    }
-
     function conditionFromIfElseBlock(block) {
       return block?.parExpr()?.condition();
     }
@@ -141,12 +128,7 @@ export default {
       return block?.braceBlock()?.block();
     }
 
-    function toggleEditable(block, editable) {
-      editableMap.value.set(block, editable);
-    }
-
     return {
-      editableMap,
       numbering,
       from,
       alt,
@@ -155,7 +137,6 @@ export default {
       elseIfBlocks,
       elseBlock,
       blockLengthAcc,
-      toggleEditable,
       conditionFromIfElseBlock,
       blockInElseIfBlock,
       increaseNumber,

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentAlt.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentAlt.vue
@@ -170,10 +170,4 @@ export default {
 * {
   border-color: inherit;
 }
-
-.condition.editable {
-  padding: 2px 6px;
-  margin-left: 4px;
-  cursor: text;
-}
 </style>

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentAlt.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentAlt.vue
@@ -46,7 +46,7 @@
         <div class="segment mt-2 border-t border-solid">
           <div class="text-skin-fragment" :key="index + 1000">
             <label class="else-if hidden">else if</label>
-            <EditableLabel
+            <ConditionLabel
               :block="elseIfBlock"
               :getConditionFromBlock="conditionFromIfElseBlock"
             />

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentLoop.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentLoop.vue
@@ -68,17 +68,6 @@ export default {
       editable.value = _editable;
     };
 
-    // const {
-    //   handleDblClick,
-    //   handleBlur,
-    //   handleKeydown,
-    //   handleKeyup,
-    // } = useConditionEdit({
-    //   blocks: [blockInLoop.value],
-    //   getCondition: () => condition.value,
-    //   getConditionText: () => conditionText.value,
-    // });
-
     return {
       numbering,
       from,
@@ -95,10 +84,5 @@ export default {
 /* We need to do this because tailwind 3.2.4 set border-color to #e5e7eb via '*'. */
 * {
   border-color: inherit;
-}
-.condition.editable {
-  padding: 2px 6px;
-  margin-left: 4px;
-  cursor: text;
 }
 </style>

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentLoop.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentLoop.vue
@@ -26,7 +26,7 @@
     <div :class="{ hidden: collapsed }">
       <div class="segment">
         <div class="text-skin-fragment">
-          <EditableLabel
+          <ConditionLabel
             :editable="editable"
             :toggleEditable="toggleEditable"
             :block="blockInLoop"
@@ -45,17 +45,17 @@
 </template>
 
 <script>
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useStore } from "vuex";
 import fragment from "./FragmentMixin";
-import EditableLabel from "../../EditableLabel.vue";
+import ConditionLabel from "./ConditionLabel.vue";
 
 export default {
   name: "fragment-loop",
   props: ["context", "comment", "commentObj", "selfCallIndent", "number"],
   mixins: [fragment],
   components: {
-    EditableLabel,
+    ConditionLabel,
   },
   setup(props) {
     const store = useStore();
@@ -63,18 +63,12 @@ export default {
     const from = computed(() => props.context.Origin());
     const loop = computed(() => props.context.loop());
     const blockInLoop = computed(() => loop.value?.braceBlock()?.block());
-    const editable = ref(false);
-    const toggleEditable = (_editable) => {
-      editable.value = _editable;
-    };
 
     return {
       numbering,
       from,
       loop,
       blockInLoop,
-      editable,
-      toggleEditable,
       getConditionFromBlock: () => loop.value?.parExpr()?.condition(),
     };
   },

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentLoop.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentLoop.vue
@@ -26,7 +26,12 @@
     <div :class="{ hidden: collapsed }">
       <div class="segment">
         <div class="text-skin-fragment">
-          <label class="condition p-1">[{{ condition }}]</label>
+          <EditableLabel
+            :editable="editable"
+            :toggleEditable="toggleEditable"
+            :block="blockInLoop"
+            :getConditionFromBlock="getConditionFromBlock"
+          />
         </div>
         <block
           :style="{ paddingLeft: `${offsetX}px` }"
@@ -40,27 +45,49 @@
 </template>
 
 <script>
-import { mapState } from "vuex";
+import { computed, ref } from "vue";
+import { useStore } from "vuex";
 import fragment from "./FragmentMixin";
+import EditableLabel from "../../EditableLabel.vue";
 
 export default {
   name: "fragment-loop",
   props: ["context", "comment", "commentObj", "selfCallIndent", "number"],
   mixins: [fragment],
-  computed: {
-    ...mapState(["numbering"]),
-    from: function () {
-      return this.context.Origin();
-    },
-    loop: function () {
-      return this.context.loop();
-    },
-    blockInLoop: function () {
-      return this.loop?.braceBlock()?.block();
-    },
-    condition: function () {
-      return this.loop?.parExpr()?.condition()?.getFormattedText();
-    },
+  components: {
+    EditableLabel,
+  },
+  setup(props) {
+    const store = useStore();
+    const numbering = computed(() => store.state.numbering);
+    const from = computed(() => props.context.Origin());
+    const loop = computed(() => props.context.loop());
+    const blockInLoop = computed(() => loop.value?.braceBlock()?.block());
+    const editable = ref(false);
+    const toggleEditable = (_editable) => {
+      editable.value = _editable;
+    };
+
+    // const {
+    //   handleDblClick,
+    //   handleBlur,
+    //   handleKeydown,
+    //   handleKeyup,
+    // } = useConditionEdit({
+    //   blocks: [blockInLoop.value],
+    //   getCondition: () => condition.value,
+    //   getConditionText: () => conditionText.value,
+    // });
+
+    return {
+      numbering,
+      from,
+      loop,
+      blockInLoop,
+      editable,
+      toggleEditable,
+      getConditionFromBlock: () => loop.value?.parExpr()?.condition(),
+    };
   },
 };
 </script>
@@ -68,5 +95,10 @@ export default {
 /* We need to do this because tailwind 3.2.4 set border-color to #e5e7eb via '*'. */
 * {
   border-color: inherit;
+}
+.condition.editable {
+  padding: 2px 6px;
+  margin-left: 4px;
+  cursor: text;
 }
 </style>


### PR DESCRIPTION
Introduce a new component `<ConditonLabel />`. It allows users to select condition labels on diagram and edit the text which will update the actual code.

### Features
- Labels switch to edit mode with a double click
- Editing can be finished by entering 'enter', 'tab', or 'esc' key, or by losing focus
- Empty strings will revert the label back to its original text
- Conditions in code will be wrapped with double quotes if there are special characters in the condition label
- Highlight condition label,  change cursor to text cursor type, and pop up "Double to edit" tooltip when hovering hover


### Changes
- Create a new `<ConditionLabel />` component with different event handlers to control its state
- Refactor `<FragmentAlt />` and `<FragmentLoop />` with `<ConditionLabel />`
- Fix a minor issue in `<LifeLineLayer />`

### Snapshots
![image](https://github.com/mermaid-js/zenuml-core/assets/3481791/0e08420f-da05-47d9-b8a3-14f9a628c6eb)
![image](https://github.com/mermaid-js/zenuml-core/assets/3481791/d957d896-df37-4d84-b3a7-b7190737ffb3)
![image](https://github.com/mermaid-js/zenuml-core/assets/3481791/1ce7f025-b190-4613-a603-d7cb9d60a46b)



#112 