### PR TITLE
Fix/#183-unable-edit-label

### DIFF
--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.vue
@@ -32,7 +32,7 @@
         :labelText="labelText"
         :labelPositions="labelPositions"
         :assignee="entity.assignee"
-        :assigneePosition="assigneePosition"
+        :assigneePositions="assigneePositions"
       />
     </div>
   </div>
@@ -68,12 +68,17 @@ export default {
       const positions = store.getters.participants.GetPositions(
         props.entity.name,
       );
-      // Sort the label positions in descending order to avoid index shifting
-      const positionArray = Array.from(positions || []).map(JSON.parse);
+      // Sort the label positions in descending order to avoid index shifting when updating code
+      const positionArray = Array.from(positions ?? []);
       return positionArray.sort((a, b) => b[0] - a[0]);
     });
-    const assigneePosition = computed(() => {
-      return store.getters.participants.GetAssigneePosition(props.entity.name);
+    const assigneePositions = computed(() => {
+      // Sort the label positions in descending order to avoid index shifting when updating code
+      const assigneePositions = store.getters.participants.GetAssigneePositions(
+        props.entity.name,
+      );
+      const positionArray = Array.from(assigneePositions ?? []);
+      return positionArray.sort((a, b) => b[0] - a[0]);
     });
     const intersectionTop = useIntersectionTop();
     const [scrollTop] = useDocumentScroll();
@@ -95,7 +100,7 @@ export default {
         participantOffsetTop
       );
     });
-    return { translate, participant, labelPositions, assigneePosition };
+    return { translate, participant, labelPositions, assigneePositions };
   },
   props: {
     entity: {
@@ -106,10 +111,6 @@ export default {
     offsetTop2: {
       type: Number,
       default: 0,
-    },
-    context: {
-      type: Object,
-      required: false,
     },
   },
   data() {

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.vue
@@ -32,6 +32,7 @@
         :labelText="labelText"
         :labelPositions="labelPositions"
         :assignee="entity.assignee"
+        :assigneePosition="assigneePosition"
       />
     </div>
   </div>
@@ -63,9 +64,17 @@ export default {
       return { translate: 0, participant };
     }
 
-    const labelPositions = computed(() =>
-      store.getters.participants.Positions().get(props.entity.name),
-    );
+    const labelPositions = computed(() => {
+      const positions = store.getters.participants.GetPositions(
+        props.entity.name,
+      );
+      // Sort the label positions in descending order to avoid index shifting
+      const positionArray = Array.from(positions || []).map(JSON.parse);
+      return positionArray.sort((a, b) => b[0] - a[0]);
+    });
+    const assigneePosition = computed(() => {
+      return store.getters.participants.GetAssigneePosition(props.entity.name);
+    });
     const intersectionTop = useIntersectionTop();
     const [scrollTop] = useDocumentScroll();
     const translate = computed(() => {
@@ -86,7 +95,7 @@ export default {
         participantOffsetTop
       );
     });
-    return { translate, participant, labelPositions };
+    return { translate, participant, labelPositions, assigneePosition };
   },
   props: {
     entity: {
@@ -97,6 +106,10 @@ export default {
     offsetTop2: {
       type: Number,
       default: 0,
+    },
+    context: {
+      type: Object,
+      required: false,
     },
   },
   data() {

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/ParticipantLabel.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/ParticipantLabel.vue
@@ -27,7 +27,7 @@
       :contenteditable="
         participantLabelHandler.editing &&
         mode === RenderMode.Dynamic &&
-        InvalidText.indexOf(labelText) === -1
+        UneditableText.indexOf(labelText) === -1
       "
       @dblclick="participantLabelHandler.handleDblClick"
       @blur="participantLabelHandler.handleBlur"
@@ -45,7 +45,7 @@ import { useEditLabel, specialCharRegex } from "@/functions/useEditLabel";
 import { RenderMode } from "@/store/Store";
 import { Position } from "@/parser/Participants";
 
-const InvalidText = ["Missing Constructor"];
+const UneditableText = ["Missing Constructor", "ZenUML"];
 
 const props = defineProps<{
   labelText: string;

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/ParticipantLabel.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/ParticipantLabel.vue
@@ -1,37 +1,56 @@
 <template>
   <div class="flex items-center justify-center">
     <template v-if="assignee">
-      <label class="name leading-4">{{ assignee }}:</label>
+      <label
+        title="Double click to edit"
+        class="name leading-4 cursor-text right hover:text-skin-message-hover hover:bg-skin-message-hover"
+        :class="{
+          'py-1 cursor-text': assigneeLabelHandler.editing,
+        }"
+        :contenteditable="
+          assigneeLabelHandler.editing && mode === RenderMode.Dynamic
+        "
+        @dblclick="assigneeLabelHandler.handleDblClick"
+        @blur="assigneeLabelHandler.handleBlur"
+        @keyup="assigneeLabelHandler.handleKeyup"
+        @keydown="assigneeLabelHandler.handleKeydown"
+        >{{ assignee }}</label
+      >
+      <span>:</span>
     </template>
     <label
       title="Double click to edit"
       class="name leading-4 cursor-text right hover:text-skin-message-hover hover:bg-skin-message-hover"
       :class="{
-        'py-1 px-2 cursor-text': editing,
+        'py-1 cursor-text': participantLabelHandler.editing,
       }"
-      :contenteditable="editing && mode === RenderMode.Dynamic"
-      @dblclick="handleDblClick"
-      @blur="handleBlur"
-      @keyup="handleKeyup"
-      @keydown="handleKeydown"
+      :contenteditable="
+        participantLabelHandler.editing && mode === RenderMode.Dynamic
+      "
+      @dblclick="participantLabelHandler.handleDblClick"
+      @blur="participantLabelHandler.handleBlur"
+      @keyup="participantLabelHandler.handleKeyup"
+      @keydown="participantLabelHandler.handleKeydown"
     >
       {{ labelText }}
     </label>
   </div>
 </template>
 <script setup lang="ts">
-import { computed, toRefs } from "vue";
+import { computed } from "vue";
 import { useStore } from "vuex";
 import { useEditLabel, specialCharRegex } from "@/functions/useEditLabel";
 import { RenderMode } from "@/store/Store";
+import { Position } from "@/parser/Participants";
 
 const props = defineProps<{
   labelText: string;
-  labelPositions?: Set<string>;
+  labelPositions?: Array<[number, number]>;
   assignee?: string;
+  assigneePosition?: [number, number];
 }>();
 
-const { labelText, labelPositions } = toRefs(props);
+const { labelText, labelPositions = [], assigneePosition = [-1, -1] } = props;
 const store = useStore();
 const mode = computed(() => store.state.mode);
 const code = computed(() => store.getters.code);
@@ -45,48 +64,48 @@ function updateCode(code: string) {
   onContentChange.value(code);
 }
 
-function replaceLabelText(e: Event) {
-  e.preventDefault();
-  e.stopPropagation();
+function replaceLabelTextWithaPositions(positions: Array<Position>) {
+  return function (e: Event) {
+    e.preventDefault();
+    e.stopPropagation();
 
-  const target = e.target;
-  if (!(target instanceof HTMLElement)) return;
-  let newText = target.innerText.trim() ?? "";
+    const target = e.target;
+    if (!(target instanceof HTMLElement)) return;
+    let newText = target.innerText.trim() ?? "";
 
-  // If text is empty or same as the original label text,
-  // we replace it with the original label text and bail out early
-  if (newText === "" || newText === labelText.value) {
-    target.innerText = labelText.value;
-    return;
-  }
+    // If text is empty or same as the original label text,
+    // we replace it with the original label text and bail out early
+    if (newText === "" || newText === labelText) {
+      target.innerText = labelText;
+      return;
+    }
 
-  if (newText.includes(" ")) {
-    newText = newText.replace(/\s+/g, " "); // remove extra spaces
-  }
+    if (newText.includes(" ")) {
+      newText = newText.replace(/\s+/g, " "); // remove extra spaces
+    }
 
-  // If text has special characters or space, we wrap it with double quotes
-  if (specialCharRegex.test(newText)) {
-    newText = newText.replace(/"/g, ""); // remove existing double quotes
-    newText = `"${newText}"`;
-    specialCharRegex.lastIndex = 0;
-  }
+    // If text has special characters or space, we wrap it with double quotes
+    if (specialCharRegex.test(newText)) {
+      newText = newText.replace(/"/g, ""); // remove existing double quotes
+      newText = `"${newText}"`;
+      specialCharRegex.lastIndex = 0;
+    }
 
-  if (!labelPositions?.value) return;
+    if (!positions || positions.length === 0) return;
 
-  // Sort the label positions in descending order to avoid index shifting
-  const labelPositionsArray = Array.from(labelPositions.value);
-  const reversedSortedLabelPositions = labelPositionsArray.sort(
-    (a, b) => JSON.parse(b)[0] - JSON.parse(a)[0],
-  );
-
-  let newCode = code.value;
-  for (const labelPosition of reversedSortedLabelPositions) {
-    const [start, end] = JSON.parse(labelPosition);
-    newCode = newCode.slice(0, start) + newText + newCode.slice(end);
-  }
-  updateCode(newCode);
+    let newCode = code.value;
+    for (const position of positions) {
+      const [start, end] = position;
+      newCode = newCode.slice(0, start) + newText + newCode.slice(end);
+    }
+    updateCode(newCode);
+  };
 }
 
-const { editing, handleDblClick, handleBlur, handleKeydown, handleKeyup } =
-  useEditLabel(replaceLabelText);
+const participantLabelHandler = useEditLabel(
+  replaceLabelTextWithaPositions(labelPositions),
+);
+const assigneeLabelHandler = useEditLabel(
+  replaceLabelTextWithaPositions([assigneePosition]),
+);
 </script>

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/ParticipantLabel.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/ParticipantLabel.vue
@@ -25,7 +25,9 @@
         'py-1 cursor-text': participantLabelHandler.editing,
       }"
       :contenteditable="
-        participantLabelHandler.editing && mode === RenderMode.Dynamic
+        participantLabelHandler.editing &&
+        mode === RenderMode.Dynamic &&
+        InvalidText.indexOf(labelText) === -1
       "
       @dblclick="participantLabelHandler.handleDblClick"
       @blur="participantLabelHandler.handleBlur"
@@ -43,14 +45,16 @@ import { useEditLabel, specialCharRegex } from "@/functions/useEditLabel";
 import { RenderMode } from "@/store/Store";
 import { Position } from "@/parser/Participants";
 
+const InvalidText = ["Missing Constructor"];
+
 const props = defineProps<{
   labelText: string;
   labelPositions?: Array<[number, number]>;
   assignee?: string;
-  assigneePosition?: [number, number];
+  assigneePositions?: Array<[number, number]>;
 }>();
 
-const { labelText, labelPositions = [], assigneePosition = [-1, -1] } = props;
+const { labelText, labelPositions = [], assigneePositions = [] } = props;
 const store = useStore();
 const mode = computed(() => store.state.mode);
 const code = computed(() => store.getters.code);
@@ -106,6 +110,6 @@ const participantLabelHandler = useEditLabel(
   replaceLabelTextWithaPositions(labelPositions),
 );
 const assigneeLabelHandler = useEditLabel(
-  replaceLabelTextWithaPositions([assigneePosition]),
+  replaceLabelTextWithaPositions(assigneePositions),
 );
 </script>

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Interaction/SelfInvocation/SelfInvocation.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Interaction/SelfInvocation/SelfInvocation.vue
@@ -61,6 +61,7 @@ const messageRef = ref();
 const labelPosition: ComputedRef<[number, number]> = computed(() => {
   // do not use .signature(). Multiple signatures are allowed, e.g. method().method1().method2()
   const func = context?.value.messageBody().func();
+  if (!func) return [-1, -1];
   return [func.start.start, func.stop.stop];
 });
 

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Message/Message.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Message/Message.vue
@@ -101,12 +101,12 @@ const labelText = computed(() => {
   switch (type?.value) {
     case "creation":
       // Extract the creation name from the content
-      return content?.value.match(creationRegex)?.[1];
+      return content?.value.match(creationRegex)?.[1] || "";
     case "sync":
     case "async":
     case "return":
     default:
-      return content?.value;
+      return content?.value || "";
   }
 });
 const labelPosition: ComputedRef<[number, number]> = computed(() => {
@@ -144,6 +144,9 @@ const labelPosition: ComputedRef<[number, number]> = computed(() => {
           [start, stop] = [ret?.start.start, ret?.stop.stop];
         } else if (context?.value instanceof sequenceParser.ContentContext) {
           [start, stop] = [context.value.start.start, context.value.stop.stop];
+        } else if (context?.value instanceof sequenceParser.AssignmentContext) {
+          const assignee = context.value.assignee();
+          [start, stop] = [assignee.start.start, assignee.stop.stop];
         }
       }
       break;

--- a/src/parser/Owner.js
+++ b/src/parser/Owner.js
@@ -9,6 +9,14 @@ CreationContext.prototype.Assignee = function () {
   return this.creationBody()?.assignment()?.assignee()?.getFormattedText();
 };
 
+CreationContext.prototype.AssigneePosition = function () {
+  const assignee = this.creationBody()?.assignment()?.assignee();
+  if (!assignee) {
+    return undefined;
+  }
+  return [assignee.start.start, assignee.stop.stop + 1];
+};
+
 CreationContext.prototype.Constructor = function () {
   return this.creationBody()?.construct()?.getFormattedText();
 };

--- a/src/parser/Participants.spec.ts
+++ b/src/parser/Participants.spec.ts
@@ -1,15 +1,13 @@
-import { Participants } from "../parser/Participants";
+import { blankParticipant, Participants } from "../parser/Participants";
 
 describe("Participants", () => {
   test("Get implicitly declared participants", () => {
     const participants = new Participants();
     participants.Add("A");
-    expect(participants.ImplicitArray()).toEqual([
+    expect(participants.ImplicitArray().map((p) => p.ToValue())).toEqual([
       {
+        ...blankParticipant,
         name: "A",
-        isStarter: undefined,
-        stereotype: undefined,
-        width: undefined,
       },
     ]);
     expect(participants.Starter()).toBeUndefined();
@@ -21,16 +19,12 @@ describe("Participants", () => {
     participants.Add("A");
     expect(participants.ImplicitArray()).toEqual([
       {
+        ...blankParticipant,
         name: "B",
-        isStarter: undefined,
-        stereotype: undefined,
-        width: undefined,
       },
       {
+        ...blankParticipant,
         name: "A",
-        isStarter: undefined,
-        stereotype: undefined,
-        width: undefined,
       },
     ]);
     expect(participants.Starter()).toBeUndefined();
@@ -40,24 +34,22 @@ describe("Participants", () => {
     const participants = new Participants();
     participants.Add("A", { isStarter: true });
     expect(participants.Starter()).toEqual({
+      ...blankParticipant,
       name: "A",
       isStarter: true,
-      stereotype: undefined,
-      width: undefined,
     });
     participants.Add("A", {
+      ...blankParticipant,
       isStarter: false,
-      start: 1,
-      end: 2,
+      position: [1, 2],
       explicit: true,
     });
     expect(participants.Starter()).toEqual({
+      ...blankParticipant,
       name: "A",
       isStarter: true,
-      stereotype: undefined,
-      width: undefined,
       explicit: true,
+      positions: new Set([[1, 2]]),
     });
-    expect(participants.GetPositions("A")?.has("[1,2]"));
   });
 });

--- a/src/parser/SignatureText.ts
+++ b/src/parser/SignatureText.ts
@@ -24,8 +24,8 @@ AsyncMessageContext.prototype.SignatureText = function () {
 // @ts-ignore
 CreationContext.prototype.SignatureText = function () {
   const params = this.creationBody().parameters();
-  // @ts-ignore
   const text =
+    // @ts-ignore
     params?.parameter()?.length > 0 ? params.getFormattedText() : "create";
   return "«" + text + "»";
 };

--- a/src/parser/ToCollector.js
+++ b/src/parser/ToCollector.js
@@ -46,8 +46,6 @@ const onParticipant = function (ctx) {
 
   participants.Add(participant, {
     isStarter: false,
-    start,
-    end,
     type,
     stereotype,
     width,
@@ -56,6 +54,7 @@ const onParticipant = function (ctx) {
     explicit,
     color,
     comment,
+    position: [start, end],
   });
 };
 ToCollector.enterParticipant = onParticipant;
@@ -71,17 +70,22 @@ const onTo = function (ctx) {
   } else if (participantInstance?.assignee) {
     // If the participant has an assignee, calculate the position of the ctor and store it only.
     // Let's say the participant name is `"${assignee}:${type}"`, we need to get the position of ${type}
+    // e.g. ret = new A() "ret:A".method()
     const start = ctx.start.start + participantInstance.assignee.length + 2;
+    const position = [start, ctx.stop.stop];
+    const assigneePosition = [
+      ctx.start.start + 1,
+      ctx.start.start + participantInstance.assignee.length + 1,
+    ];
     participants.Add(participant, {
       isStarter: false,
-      start: start,
-      end: ctx.stop.stop,
+      position: position,
+      assigneePosition: assigneePosition,
     });
   } else {
     participants.Add(participant, {
       isStarter: false,
-      start: ctx.start.start,
-      end: ctx.stop.stop + 1,
+      position: [ctx.start.start, ctx.stop.stop + 1],
     });
   }
 };
@@ -93,8 +97,7 @@ ToCollector.enterStarter = function (ctx) {
   let participant = ctx.getFormattedText();
   participants.Add(participant, {
     isStarter: true,
-    start: ctx.start.start,
-    end: ctx.stop.stop + 1,
+    position: [ctx.start.start, ctx.stop.stop + 1],
   });
 };
 
@@ -109,13 +112,14 @@ ToCollector.enterCreation = function (ctx) {
     const assigneePosition = ctx.AssigneePosition();
     participants.Add(participant, {
       isStarter: false,
-      start: ctor.start.start,
-      end: ctor.stop.stop + 1,
+      position: [ctor.start.start, ctor.stop.stop + 1],
       assignee: assignee,
       assigneePosition: assigneePosition,
     });
   } else {
-    participants.Add(participant, { isStarter: false });
+    participants.Add(participant, {
+      isStarter: false,
+    });
   }
 };
 

--- a/src/parser/ToCollector.js
+++ b/src/parser/ToCollector.js
@@ -1,8 +1,8 @@
 import { Participants } from "./Participants";
-
 import antlr4 from "antlr4";
 import { default as sequenceParserListener } from "../generated-parser/sequenceParserListener";
 import { default as sequenceParser } from "../generated-parser/sequenceParser";
+
 const seqParser = sequenceParser;
 const ProgContext = seqParser.ProgContext;
 
@@ -14,7 +14,7 @@ const ToCollector = new sequenceParserListener();
 // Rules:
 // 1. Later declaration win
 // 2. Participant declaration overwrite cannot be overwritten by To or Starter
-let onParticipant = function (ctx) {
+const onParticipant = function (ctx) {
   // if(!(ctx?.name())) return;
   if (isBlind) return;
   const type = ctx?.participantType()?.getFormattedText().replace("@", "");
@@ -60,7 +60,7 @@ let onParticipant = function (ctx) {
 };
 ToCollector.enterParticipant = onParticipant;
 
-let onTo = function (ctx) {
+const onTo = function (ctx) {
   if (isBlind) return;
   let participant = ctx.getFormattedText();
   const participantInstance = participants.Get(participant);
@@ -106,11 +106,13 @@ ToCollector.enterCreation = function (ctx) {
   // Skip adding participant constructor position if label is present
   if (ctor && !participantInstance?.label) {
     const assignee = ctx.Assignee();
+    const assigneePosition = ctx.AssigneePosition();
     participants.Add(participant, {
       isStarter: false,
       start: ctor.start.start,
       end: ctor.stop.stop + 1,
       assignee: assignee,
+      assigneePosition: assigneePosition,
     });
   } else {
     participants.Add(participant, { isStarter: false });


### PR DESCRIPTION
Fixed issue of assignee label not being able to edit.

Changes:
1. Refactors `Participant` class by adding new `positions` and `assigneePositions` properties and new `mergeOptions` and `ToValue` properties. This makes it easier to keep track of each participant's label and assignee positions.
2. Refactor ToCollector's `onTo` and `enterCreation` methods which include adding `assignePositions` when adding new `Participant` instance.
3. Make `assignee` label editable in `ParticipantLabel` component.
 


https://github.com/user-attachments/assets/08215280-db2d-4a68-9d68-6330a4162240



