### PR TITLE
Refactor ParticipantLabel.vue component

### DIFF
--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.vue
@@ -32,6 +32,7 @@
         :labelText="labelText"
         :labelPositions="labelPositions"
         :assignee="entity.assignee"
+        :assigneePositions="assigneePositions"
       />
     </div>
   </div>
@@ -63,9 +64,22 @@ export default {
       return { translate: 0, participant };
     }
 
-    const labelPositions = computed(() =>
-      store.getters.participants.Positions().get(props.entity.name),
-    );
+    const labelPositions = computed(() => {
+      const positions = store.getters.participants.GetPositions(
+        props.entity.name,
+      );
+      // Sort the label positions in descending order to avoid index shifting when updating code
+      const positionArray = Array.from(positions ?? []);
+      return positionArray.sort((a, b) => b[0] - a[0]);
+    });
+    const assigneePositions = computed(() => {
+      // Sort the label positions in descending order to avoid index shifting when updating code
+      const assigneePositions = store.getters.participants.GetAssigneePositions(
+        props.entity.name,
+      );
+      const positionArray = Array.from(assigneePositions ?? []);
+      return positionArray.sort((a, b) => b[0] - a[0]);
+    });
     const intersectionTop = useIntersectionTop();
     const [scrollTop] = useDocumentScroll();
     const translate = computed(() => {
@@ -86,7 +100,7 @@ export default {
         participantOffsetTop
       );
     });
-    return { translate, participant, labelPositions };
+    return { translate, participant, labelPositions, assigneePositions };
   },
   props: {
     entity: {

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/ParticipantLabel.vue
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/ParticipantLabel.vue
@@ -1,19 +1,38 @@
 <template>
   <div class="flex items-center justify-center">
     <template v-if="assignee">
-      <label class="name leading-4">{{ assignee }}:</label>
+      <label
+        title="Double click to edit"
+        class="name leading-4 cursor-text right hover:text-skin-message-hover hover:bg-skin-message-hover"
+        :class="{
+          'py-1 cursor-text': assigneeLabelHandler.editing,
+        }"
+        :contenteditable="
+          assigneeLabelHandler.editing && mode === RenderMode.Dynamic
+        "
+        @dblclick="assigneeLabelHandler.handleDblClick"
+        @blur="assigneeLabelHandler.handleBlur"
+        @keyup="assigneeLabelHandler.handleKeyup"
+        @keydown="assigneeLabelHandler.handleKeydown"
+        >{{ assignee }}</label
+      >
+      <span>:</span>
     </template>
     <label
       title="Double click to edit"
       class="name leading-4 cursor-text right hover:text-skin-message-hover hover:bg-skin-message-hover"
       :class="{
-        'py-1 px-2 cursor-text': editing,
+        'py-1 cursor-text': participantLabelHandler.editing,
       }"
-      :contenteditable="editing && mode === RenderMode.Dynamic"
-      @dblclick="handleDblClick"
-      @blur="handleBlur"
-      @keyup="handleKeyup"
-      @keydown="handleKeydown"
+      :contenteditable="
+        participantLabelHandler.editing &&
+        mode === RenderMode.Dynamic &&
+        UneditableText.indexOf(labelText) === -1
+      "
+      @dblclick="participantLabelHandler.handleDblClick"
+      @blur="participantLabelHandler.handleBlur"
+      @keyup="participantLabelHandler.handleKeyup"
+      @keydown="participantLabelHandler.handleKeydown"
     >
       {{ labelText }}
     </label>
@@ -24,14 +43,19 @@ import { computed, toRefs } from "vue";
 import { useStore } from "vuex";
 import { useEditLabel, specialCharRegex } from "@/functions/useEditLabel";
 import { RenderMode } from "@/store/Store";
+import { Position } from "@/parser/Participants";
+
+const UneditableText = ["Missing Constructor", "ZenUML"];
 
 const props = defineProps<{
   labelText: string;
-  labelPositions?: Set<string>;
+  labelPositions?: Array<[number, number]>;
   assignee?: string;
+  assigneePositions?: Array<[number, number]>;
 }>();
 
-const { labelText, labelPositions } = toRefs(props);
+const { labelText, labelPositions, assigneePositions } = toRefs(props);
+
 const store = useStore();
 const mode = computed(() => store.state.mode);
 const code = computed(() => store.getters.code);
@@ -45,48 +69,48 @@ function updateCode(code: string) {
   onContentChange.value(code);
 }
 
-function replaceLabelText(e: Event) {
-  e.preventDefault();
-  e.stopPropagation();
+function replaceLabelTextWithaPositions(positions: Array<Position>) {
+  return function (e: Event) {
+    e.preventDefault();
+    e.stopPropagation();
 
-  const target = e.target;
-  if (!(target instanceof HTMLElement)) return;
-  let newText = target.innerText.trim() ?? "";
+    const target = e.target;
+    if (!(target instanceof HTMLElement)) return;
+    let newText = target.innerText.trim() ?? "";
 
-  // If text is empty or same as the original label text,
-  // we replace it with the original label text and bail out early
-  if (newText === "" || newText === labelText.value) {
-    target.innerText = labelText.value;
-    return;
-  }
+    // If text is empty or same as the original label text,
+    // we replace it with the original label text and bail out early
+    if (newText === "" || newText === labelText.value) {
+      target.innerText = labelText.value;
+      return;
+    }
 
-  if (newText.includes(" ")) {
-    newText = newText.replace(/\s+/g, " "); // remove extra spaces
-  }
+    if (newText.includes(" ")) {
+      newText = newText.replace(/\s+/g, " "); // remove extra spaces
+    }
 
-  // If text has special characters or space, we wrap it with double quotes
-  if (specialCharRegex.test(newText)) {
-    newText = newText.replace(/"/g, ""); // remove existing double quotes
-    newText = `"${newText}"`;
-    specialCharRegex.lastIndex = 0;
-  }
+    // If text has special characters or space, we wrap it with double quotes
+    if (specialCharRegex.test(newText)) {
+      newText = newText.replace(/"/g, ""); // remove existing double quotes
+      newText = `"${newText}"`;
+      specialCharRegex.lastIndex = 0;
+    }
 
-  if (!labelPositions?.value) return;
+    if (!positions || positions.length === 0) return;
 
-  // Sort the label positions in descending order to avoid index shifting
-  const labelPositionsArray = Array.from(labelPositions.value);
-  const reversedSortedLabelPositions = labelPositionsArray.sort(
-    (a, b) => JSON.parse(b)[0] - JSON.parse(a)[0],
-  );
-
-  let newCode = code.value;
-  for (const labelPosition of reversedSortedLabelPositions) {
-    const [start, end] = JSON.parse(labelPosition);
-    newCode = newCode.slice(0, start) + newText + newCode.slice(end);
-  }
-  updateCode(newCode);
+    let newCode = code.value;
+    for (const position of positions) {
+      const [start, end] = position;
+      newCode = newCode.slice(0, start) + newText + newCode.slice(end);
+    }
+    updateCode(newCode);
+  };
 }
 
-const { editing, handleDblClick, handleBlur, handleKeydown, handleKeyup } =
-  useEditLabel(replaceLabelText);
+const participantLabelHandler = useEditLabel(
+  replaceLabelTextWithaPositions(labelPositions?.value ?? []),
+);
+const assigneeLabelHandler = useEditLabel(
+  replaceLabelTextWithaPositions(assigneePositions?.value ?? []),
+);
 </script>

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Interaction/SelfInvocation/SelfInvocation.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Interaction/SelfInvocation/SelfInvocation.vue
@@ -61,6 +61,7 @@ const messageRef = ref();
 const labelPosition: ComputedRef<[number, number]> = computed(() => {
   // do not use .signature(). Multiple signatures are allowed, e.g. method().method1().method2()
   const func = context?.value.messageBody().func();
+  if (!func) return [-1, -1];
   return [func.start.start, func.stop.stop];
 });
 

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Message/Message.vue
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Message/Message.vue
@@ -101,12 +101,12 @@ const labelText = computed(() => {
   switch (type?.value) {
     case "creation":
       // Extract the creation name from the content
-      return content?.value.match(creationRegex)?.[1];
+      return content?.value.match(creationRegex)?.[1] || "";
     case "sync":
     case "async":
     case "return":
     default:
-      return content?.value;
+      return content?.value || "";
   }
 });
 const labelPosition: ComputedRef<[number, number]> = computed(() => {
@@ -144,6 +144,9 @@ const labelPosition: ComputedRef<[number, number]> = computed(() => {
           [start, stop] = [ret?.start.start, ret?.stop.stop];
         } else if (context?.value instanceof sequenceParser.ContentContext) {
           [start, stop] = [context.value.start.start, context.value.stop.stop];
+        } else if (context?.value instanceof sequenceParser.AssignmentContext) {
+          const assignee = context.value.assignee();
+          [start, stop] = [assignee.start.start, assignee.stop.stop];
         }
       }
       break;

--- a/src/parser/Owner.js
+++ b/src/parser/Owner.js
@@ -9,6 +9,14 @@ CreationContext.prototype.Assignee = function () {
   return this.creationBody()?.assignment()?.assignee()?.getFormattedText();
 };
 
+CreationContext.prototype.AssigneePosition = function () {
+  const assignee = this.creationBody()?.assignment()?.assignee();
+  if (!assignee) {
+    return undefined;
+  }
+  return [assignee.start.start, assignee.stop.stop + 1];
+};
+
 CreationContext.prototype.Constructor = function () {
   return this.creationBody()?.construct()?.getFormattedText();
 };

--- a/src/parser/Participants.spec.ts
+++ b/src/parser/Participants.spec.ts
@@ -1,15 +1,13 @@
-import { Participants } from "../parser/Participants";
+import { blankParticipant, Participants } from "../parser/Participants";
 
 describe("Participants", () => {
   test("Get implicitly declared participants", () => {
     const participants = new Participants();
     participants.Add("A");
-    expect(participants.ImplicitArray()).toEqual([
+    expect(participants.ImplicitArray().map((p) => p.ToValue())).toEqual([
       {
+        ...blankParticipant,
         name: "A",
-        isStarter: undefined,
-        stereotype: undefined,
-        width: undefined,
       },
     ]);
     expect(participants.Starter()).toBeUndefined();
@@ -21,16 +19,12 @@ describe("Participants", () => {
     participants.Add("A");
     expect(participants.ImplicitArray()).toEqual([
       {
+        ...blankParticipant,
         name: "B",
-        isStarter: undefined,
-        stereotype: undefined,
-        width: undefined,
       },
       {
+        ...blankParticipant,
         name: "A",
-        isStarter: undefined,
-        stereotype: undefined,
-        width: undefined,
       },
     ]);
     expect(participants.Starter()).toBeUndefined();
@@ -40,24 +34,22 @@ describe("Participants", () => {
     const participants = new Participants();
     participants.Add("A", { isStarter: true });
     expect(participants.Starter()).toEqual({
+      ...blankParticipant,
       name: "A",
       isStarter: true,
-      stereotype: undefined,
-      width: undefined,
     });
     participants.Add("A", {
+      ...blankParticipant,
       isStarter: false,
-      start: 1,
-      end: 2,
+      position: [1, 2],
       explicit: true,
     });
     expect(participants.Starter()).toEqual({
+      ...blankParticipant,
       name: "A",
       isStarter: true,
-      stereotype: undefined,
-      width: undefined,
       explicit: true,
+      positions: new Set([[1, 2]]),
     });
-    expect(participants.GetPositions("A")?.has("[1,2]"));
   });
 });

--- a/src/parser/Participants.ts
+++ b/src/parser/Participants.ts
@@ -1,4 +1,3 @@
-import mergeWith from "lodash/mergeWith";
 export enum ParticipantType {
   Actor = 1,
   Boundary,
@@ -16,10 +15,10 @@ export enum ParticipantType {
   Undefined,
 }
 
+export type Position = [number, number];
+
 interface ParticipantOptions {
   isStarter?: boolean;
-  start?: number;
-  end?: number;
   stereotype?: string;
   width?: number;
   groupId?: number | string;
@@ -29,7 +28,24 @@ interface ParticipantOptions {
   color?: string;
   comment?: string;
   assignee?: string;
+  position?: Position;
+  assigneePosition?: Position;
 }
+
+export const blankParticipant = {
+  color: undefined,
+  comment: undefined,
+  explicit: undefined,
+  groupId: undefined,
+  isStarter: undefined,
+  label: undefined,
+  stereotype: undefined,
+  type: undefined,
+  width: undefined,
+  assignee: undefined,
+  positions: new Set(),
+  assigneePositions: new Set(),
+};
 
 export class Participant {
   name: string;
@@ -43,9 +59,15 @@ export class Participant {
   private color: string | undefined;
   private comment: string | undefined;
   private assignee: string | undefined;
+  positions: Set<Position> = new Set();
+  assigneePositions: Set<Position> = new Set();
 
   constructor(name: string, options: ParticipantOptions) {
     this.name = name;
+    this.mergeOptions(options);
+  }
+
+  public mergeOptions(options: ParticipantOptions) {
     const {
       stereotype,
       width,
@@ -58,16 +80,16 @@ export class Participant {
       comment,
       assignee,
     } = options;
-    this.stereotype = stereotype;
-    this.width = width;
-    this.groupId = groupId;
-    this.explicit = explicit;
-    this.isStarter = isStarter;
-    this.label = label;
-    this.type = type;
-    this.color = color;
-    this.comment = comment;
-    this.assignee = assignee;
+    this.stereotype ||= stereotype;
+    this.width ||= width;
+    this.groupId ||= groupId;
+    this.explicit ||= explicit;
+    this.isStarter ||= isStarter;
+    this.label ||= label;
+    this.type ||= type;
+    this.color ||= color;
+    this.comment ||= comment;
+    this.assignee ||= assignee;
   }
 
   public Type(): ParticipantType {
@@ -102,26 +124,49 @@ export class Participant {
     }
     return ParticipantType.Undefined;
   }
-}
 
-export type PositionStr<
-  A extends number = number,
-  B extends number = number,
-> = `[${A},${B}]`;
+  public AddPosition(position: Position) {
+    this.positions.add(position);
+  }
+
+  public ToValue() {
+    return {
+      name: this.name,
+      stereotype: this.stereotype,
+      width: this.width,
+      groupId: this.groupId,
+      explicit: this.explicit,
+      isStarter: this.isStarter,
+      label: this.label,
+      type: this.type,
+      color: this.color,
+      comment: this.comment,
+      assignee: this.assignee,
+      positions: this.positions,
+      assigneePositions: this.assigneePositions,
+    };
+  }
+}
 
 export class Participants {
   private participants = new Map<string, Participant>();
-  private participantPositions = new Map<string, Set<PositionStr>>();
 
   public Add(name: string, options: ParticipantOptions = {}): void {
-    const participant = new Participant(name, options);
-    this.participants.set(
-      name,
-      mergeWith({}, this.Get(name), participant, (a, b) => a || b),
-    );
-    const { start, end } = options;
-    if (start !== undefined && end !== undefined) {
-      this.addPosition(name, start, end);
+    let participant = this.Get(name);
+    if (!participant) {
+      participant = new Participant(name, options);
+      this.participants.set(name, participant);
+    } else {
+      participant?.mergeOptions(options);
+    }
+
+    // Add positions
+    const { position, assigneePosition } = options;
+    if (position) {
+      participant.AddPosition(position);
+    }
+    if (assigneePosition) {
+      participant.assigneePositions.add(assigneePosition);
     }
   }
 
@@ -158,24 +203,14 @@ export class Participants {
   Starter() {
     const first = this.First();
     // const type = first.name === 'User' || first.name === 'Actor' ? 'actor' : undefined;
-    return first.isStarter ? first : undefined;
-  }
-
-  Positions() {
-    return this.participantPositions;
+    return first?.isStarter ? first : undefined;
   }
 
   GetPositions(name: string) {
-    return this.participantPositions.get(name);
+    return this.participants.get(name)?.positions;
   }
 
-  private addPosition(name: string, start: number, end: number) {
-    let positions = this.participantPositions.get(name);
-    if (!positions) {
-      positions = new Set();
-      this.participantPositions.set(name, positions);
-    }
-
-    positions.add(`[${start},${end}]`);
+  GetAssigneePositions(name: string) {
+    return this.participants.get(name)?.assigneePositions;
   }
 }

--- a/src/parser/SignatureText.ts
+++ b/src/parser/SignatureText.ts
@@ -24,8 +24,8 @@ AsyncMessageContext.prototype.SignatureText = function () {
 // @ts-ignore
 CreationContext.prototype.SignatureText = function () {
   const params = this.creationBody().parameters();
-  // @ts-ignore
   const text =
+    // @ts-ignore
     params?.parameter()?.length > 0 ? params.getFormattedText() : "create";
   return "«" + text + "»";
 };


### PR DESCRIPTION
This MR fixes a reactivity issue introduced by #189

Root cause analysis: The component properties will lose its reactivity after deconstructing. `toRefs` ensures its reactivity.