### PR TITLE
Renames CSS class from 'container' to 'z-container' to avoid css over…

### DIFF
--- a/src/components/DiagramFrame/SeqDiagram/SeqDiagram.vue
+++ b/src/components/DiagramFrame/SeqDiagram/SeqDiagram.vue
@@ -9,7 +9,7 @@
      -->
     <div
       :style="{ paddingLeft: `${frameBorderLeft}px` }"
-      class="relative container"
+      class="relative z-container"
     >
       <template v-if="mode === RenderMode.Dynamic">
         <life-line-layer


### PR DESCRIPTION
…riding.