### PR TITLE
feat: add scroll-root support for sticky participants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Source: `src/` (React 19 renderer, TypeScript). Parser grammars in `src/g4`, generated code in `src/generated-parser`, enhancements in `src/parser`.
+- Tests: `tests/*.spec.ts` (+ `*-snapshots/`) and `test/unit/**` (Vitest setup in `test/setup.ts`). Playwright config in `playwright.config.ts`.
+- Site/demo: Vite app (entry via `index.html`, assets in `public/`). Build output in `dist/`.
+- Docs & misc: `docs/`, `.storybook/`, `scripts/`, `antlr/`.
+
+## Build, Test, and Development Commands
+- `npx pnpm install`: Install dependencies (first run via `npx`).
+- `pnpm dev`: Start Vite dev server at `http://localhost:8080`.
+- `pnpm build`: Build library bundle (Vite, `vite.config.lib.ts`).
+- `pnpm build:site`: Build demo/site; `pnpm preview` serves it.
+- `pnpm test`: Run unit tests (Vitest).
+- `pnpm pw`, `pnpm pw:ui`, `pnpm pw:smoke`: Playwright e2e tests (CLI, UI, smoke).
+- `pnpm eslint`, `pnpm prettier`: Lint and format code.
+- Cloudflare Worker: `pnpm worker:dev`, `pnpm worker:deploy` (builds site first).
+
+## Coding Style & Naming Conventions
+- Language: TypeScript (`strict: true`), React JSX (`react-jsx`). Node >= 20.
+- Indentation: 2 spaces, LF line endings (`.editorconfig`).
+- Linting: ESLint + `@typescript-eslint` + Prettier. Prefer `pnpm eslint` and fix before commit.
+- Files: use `.ts/.tsx`. Tests end with `.spec.ts`. Path alias `@/*` maps to `src/*`.
+
+## Testing Guidelines
+- Unit: Vitest + Testing Library; setup in `test/setup.ts` (e.g., IntersectionObserver mock).
+- E2E: Playwright; run `pnpm pw` or debug with `pnpm pw:ui`.
+- Snapshots: present in `*-snapshots/`. Update intentionally: `vitest -u` or `pnpm pw:update`.
+- Place new unit tests near subject in `test/unit/**` or add `.spec.ts` under `tests/` with clear names.
+
+## Commit & Pull Request Guidelines
+- Commit style: Conventional Commits (e.g., `feat:`, `fix:`, `refactor:`). Scope optional.
+- PRs: clear description, link issues, include screenshots for UI changes, update docs if behavior changes.
+- Quality gate: run `pnpm eslint`, `pnpm prettier`, `pnpm test`, and relevant Playwright suites; ensure CI passes.
+
+## Security & Configuration Tips
+- Avoid injecting raw HTML; use safe utilities (e.g., DOMPurify) where needed.
+- ANTLR: grammars in `src/g4`; regenerate via `pnpm antlr` when grammar changes.

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
           <div class="bg-gray-800 text-white px-4 py-3">
             <h3 class="font-medium">Preview</h3>
           </div>
-          <div style="height: calc(100% - 52px); overflow: auto;" class="p-4">
+          <div id="preview-scroll-root" style="height: calc(100% - 52px); overflow: auto;" class="p-4">
             <pre class="zenuml" style="margin: 0"></pre>
           </div>
         </div>
@@ -127,6 +127,7 @@
       const updateDiagram = debounce((content) => {
         const config = createConfig({
           onContentChange: (code) => editor.setValue(code),
+          scrollRoot: document.getElementById('preview-scroll-root'),
         });
 
         window.zenUml.render(content, config).then((r) => {

--- a/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.tsx
+++ b/src/components/DiagramFrame/SeqDiagram/LifeLineLayer/Participant.tsx
@@ -10,6 +10,7 @@ import {
   RenderMode,
   selectedAtom,
   stickyOffsetAtom,
+  scrollRootAtom,
 } from "@/store/Store";
 import { cn } from "@/utils";
 import { brightnessIgnoreAlpha, removeAlpha } from "@/utils/Color";
@@ -29,6 +30,7 @@ export const Participant = (props: {
   const mode = useAtomValue(modeAtom);
   const participants = useAtomValue(participantsAtom);
   const diagramElement = useAtomValue(diagramElementAtom);
+  const scrollRoot = useAtomValue(scrollRootAtom);
   const stickyOffset = useAtomValue(stickyOffsetAtom);
   const selected = useAtomValue(selectedAtom);
   const onSelect = useSetAtom(onSelectAtom);
@@ -56,7 +58,8 @@ export const Participant = (props: {
       top += stickyOffset;
     const diagramHeight = diagramElement?.clientHeight || 0;
     const diagramTop = diagramElement
-      ? getElementDistanceToTop(diagramElement)
+      ? getElementDistanceToTop(diagramElement) -
+        (scrollRoot ? getElementDistanceToTop(scrollRoot) : 0)
       : 0;
     if (top < participantOffsetTop + diagramTop) return 0;
     return (

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export function setTheme(theme: string): void {
 export const defaultConfig = {
   enableMultiTheme: true,
   stickyOffset: 0,
+  scrollRoot: null as HTMLElement | null,
   theme: getTheme(),
   onThemeChange: ({ theme }: { theme: string }) => {
     setTheme(theme);

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -11,6 +11,7 @@ import {
   renderingReadyAtom,
   RenderMode,
   stickyOffsetAtom,
+  scrollRootAtom,
   themeAtom,
 } from "./store/Store";
 import { DiagramFrame } from "./components/DiagramFrame/DiagramFrame";
@@ -40,6 +41,7 @@ interface Config {
   onThemeChange?: (data: { theme: string; scoped?: boolean }) => void;
   enableMultiTheme?: boolean;
   stickyOffset?: number;
+  scrollRoot?: HTMLElement | null;
   onContentChange?: (code: string) => void;
   onEventEmit?: (name: string, data: unknown) => void;
   mode?: RenderMode;
@@ -118,6 +120,11 @@ export default class ZenUml implements IZenUml {
     this._code = code === undefined ? this._code : code;
     this._theme = config?.theme || this._theme;
     this.store.set(stickyOffsetAtom, config?.stickyOffset || 0);
+    // Set scroll root for sticky behavior
+    // null/undefined -> default to viewport scrolling
+    // HTMLElement -> use container scroll
+    const { scrollRoot } = config || {};
+    this.store.set(scrollRootAtom, scrollRoot || null);
     this.store.set(themeAtom, this._theme || "default");
     this.store.set(
       enableScopedThemingAtom,

--- a/src/functions/useDocumentScroll.ts
+++ b/src/functions/useDocumentScroll.ts
@@ -1,19 +1,28 @@
 import { useEffect, useState } from "react";
+import { useAtomValue } from "jotai";
+import { scrollRootAtom } from "@/store/Store";
 
 export default function useDocumentScroll() {
+  const scrollRoot = useAtomValue(scrollRootAtom);
   const [scrollTop, setScrollTop] = useState(0);
   const [scrollLeft, setScrollLeft] = useState(0);
   const updateScroll = () => {
-    setScrollTop(document.documentElement.scrollTop);
-    setScrollLeft(document.documentElement.scrollLeft);
+    if (scrollRoot) {
+      setScrollTop((scrollRoot as HTMLElement).scrollTop);
+      setScrollLeft((scrollRoot as HTMLElement).scrollLeft);
+    } else {
+      setScrollTop(document.documentElement.scrollTop);
+      setScrollLeft(document.documentElement.scrollLeft);
+    }
   };
   useEffect(() => {
     updateScroll();
     const ab = new AbortController();
-    document.addEventListener("scroll", updateScroll, { signal: ab.signal });
+    const target: any = scrollRoot || document;
+    target.addEventListener("scroll", updateScroll, { signal: ab.signal });
     return () => {
       ab.abort();
     };
-  }, []);
+  }, [scrollRoot]);
   return [scrollTop, scrollLeft];
 }

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -73,6 +73,9 @@ export const stickyOffsetAtom = atom(0);
 
 export const diagramElementAtom = atom<HTMLElement | null>(null);
 
+// Scroll root for sticky logic (null = document/viewport)
+export const scrollRootAtom = atom<HTMLElement | null>(null);
+
 export const onElementClickAtom = atomWithFunctionValue(
   (codeRange: CodeRange) => {
     console.log("Element clicked", codeRange);


### PR DESCRIPTION
- Add scrollRoot config and store atom to support sticky participants inside scrollable containers.
- Update hooks to respect custom root for scroll and intersection.
- Wire scrollRoot in preview page, restoring internal scrolling while keeping sticky working.

This keeps `scrollRoot: null` by default to preserve current behavior.
