### PR TITLE
feat: add F1 key toggle for debug mode

### DIFF
--- a/src/components/DiagramFrame/Debug/index.tsx
+++ b/src/components/DiagramFrame/Debug/index.tsx
@@ -1,7 +1,22 @@
 import Icon from "@/components/Icon/Icons";
+import { useEffect, useState } from "react";
 
 export const Debug = () => {
-  if (!localStorage.zenumlDebug) return null;
+  const [debugEnabled, setDebugEnabled] = useState(false);
+
+  useEffect(() => {
+    const handleKeyPress = (e: KeyboardEvent) => {
+      if (e.key === "F1") {
+        e.preventDefault();
+        setDebugEnabled((prev) => !prev);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyPress);
+    return () => document.removeEventListener("keydown", handleKeyPress);
+  }, []);
+
+  if (!debugEnabled) return null;
 
   return (
     <div className="text-xs inline-flex items-center font-mono font-medium leading-sm mx-1 px-3 py-1 bg-slate-100 text-slate-500 rounded-sm">


### PR DESCRIPTION
## Changes

- Added F1 key toggle to enable/disable debug mode
- Removed localStorage dependency for cleaner implementation
- Debug mode now uses React state (session-only, resets on refresh)
- All logic is self-contained in Debug component
- Works in iframe contexts when iframe has focus

## Testing
- Press F1 to toggle debug badge on/off
- Debug badge shows git branch and commit hash
- State resets on page refresh (no persistence)