### PR TITLE
perf: manualChunks to merge cloud icons in lib build output

### DIFF
--- a/.claude/skills/propagate-core-release/references/downstreams.md
+++ b/.claude/skills/propagate-core-release/references/downstreams.md
@@ -11,6 +11,7 @@ Canonical downstream targets for propagating a published `@zenuml/core` release.
 | `ZenUml/web-sequence` | `~/workspaces/zenuml/web-sequence` | yarn | `yarn upgrade @zenuml/core` | `yarn build` | HTML-renderer consumer. Do not migrate to SVG-renderer APIs during routine propagation. |
 | `ZenUml/confluence-plugin-cloud` | `~/workspaces/zenuml/confluence-plugin-cloud` | pnpm | `pnpm update @zenuml/core` | `pnpm build:full` | HTML-renderer consumer. Do not migrate to SVG-renderer APIs during routine propagation. |
 | `ZenUml/diagramly.ai` | `~/workspaces/diagramly/diagramly.ai` | pnpm | `pnpm update @zenuml/core --filter <pkg>` | `pnpm build` | HTML-renderer consumer. Do not migrate to SVG-renderer APIs during routine propagation. |
+| `ZenUml/codemirror-extensions` | `~/workspaces/zenuml/codemirror-extensions` | pnpm | `pnpm update @zenuml/core` | `pnpm build` | CodeMirror language extensions for ZenUML DSL. HTML-renderer consumer. |
 | `ZenUml/jetbrains-zenuml` | `~/workspaces/zenuml/jetbrains-zenuml` | — | See notes | — | **Not an npm consumer.** Vendors a built JS bundle. Update by copying the new `dist/` output from core's build. Skip if unsure and report. |
 
 ## Lockfile Handling

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -20,6 +20,20 @@ const gitBranch = process.env.DOCKER
   ? ""
   : execSync("git branch --show-current").toString().trim();
 
+// Merge all cloud-provider icon SVGs into a single chunk instead of 500+
+function manualChunks(id: string) {
+  if (
+    id.includes("AWS-Asset-Package") ||
+    id.includes("Architecture-Service-Icons") ||
+    id.includes("google-cloud-icons") ||
+    id.includes("Azure_Public_Service_Icons") ||
+    id.includes("HLD-Architecture") ||
+    id.includes("CloudIcons")
+  ) {
+    return "cloud-icons";
+  }
+}
+
 export default defineConfig({
   build: {
     // https://vitejs.dev/guide/build.html#library-mode
@@ -35,15 +49,11 @@ export default defineConfig({
       output: [
         {
           format: "esm",
-          // https://rollupjs.org/guide/en/#outputentryfilenames
-          // It will use the file name in `build.lib.entry` without extension as `[name]` if `[name].xxx.yyy` is provided.
-          // So we hard code as zenuml. We may consider rename `core.ts` to `zenuml.ts`.
-          // If this field is not provided, result with be ${build.lib.filename}.esm.js.
-          // Mermaid's build.ts output hardcoded esm file as '.mjs', thus we need this config.
           entryFileNames: `zenuml.esm.mjs`,
+          manualChunks,
         },
         {
-          name: "zenuml", //  it is the global variable name representing your bundle. https://rollupjs.org/guide/en/#outputname
+          name: "zenuml",
           format: "umd",
           entryFileNames: `zenuml.js`,
         },


### PR DESCRIPTION
## Summary
- Adds `manualChunks` to `vite.config.lib.ts` ESM output to merge all cloud-provider SVG chunks into a single `cloud-icons` chunk
- Published npm package file count drops from 673 to ~208
- Downstream consumers (conf-app, codemirror-extensions) see 8 dist files instead of 511
- Also adds codemirror-extensions to downstream propagation list

Follow-up to #351 — the CloudIcons barrel consolidated source-level imports, but without `manualChunks` in the lib build config, Rollup still code-split each dynamic `import()` into individual chunks in the published ESM.

## Downstream verification (codemirror-extensions)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| dist JS files | 511 | 8 | -98% |
| Res_ icon chunks | 437 | 0 | -100% |
| dist/ size | 11MB | 8.9MB | -19% |
| Build time | 1.6s | 1.4s | -12% |

## Test plan
- [x] ESLint passes
- [x] Unit tests pass (593/0)
- [x] Playwright E2E pass (78/0)
- [x] Downstream build verified with local `npm pack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)