### PR TITLE
fix: remove direct DOM manipulation in EditableSpan Escape handler

### DIFF
--- a/src/components/common/EditableSpan/EditableSpan.spec.tsx
+++ b/src/components/common/EditableSpan/EditableSpan.spec.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EditableSpan } from "./EditableSpan";
+
+describe("EditableSpan Escape cancellation", () => {
+  it("does not call onSave when Escape cancels edit", async () => {
+    const onSave = vi.fn();
+    const { container } = render(
+      <EditableSpan text="Click to add title" onSave={onSave} />,
+    );
+
+    const span = container.querySelector(".editable-span-base")! as HTMLElement;
+
+    fireEvent.click(span);
+    await waitFor(() => {
+      expect(span.getAttribute("contenteditable")).toBe("true");
+    });
+
+    span.innerText = "partial text";
+    fireEvent.keyDown(span, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(span.getAttribute("contenteditable")).toBe("false");
+    });
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("restores span content via React re-render (not direct DOM) after Escape", async () => {
+    const PLACEHOLDER = "Click to add title";
+    const onSave = vi.fn();
+    const { container } = render(
+      <EditableSpan
+        text={PLACEHOLDER}
+        className="text-gray-400 italic"
+        onSave={onSave}
+      />,
+    );
+
+    const span = container.querySelector(".editable-span-base")! as HTMLElement;
+
+    fireEvent.click(span);
+    await waitFor(() => {
+      expect(span.getAttribute("contenteditable")).toBe("true");
+    });
+
+    // Simulate user typing over the placeholder
+    span.innerText = "hello world";
+    fireEvent.keyDown(span, { key: "Escape" });
+
+    // After Escape: editing exits and content is restored to the text prop
+    await waitFor(() => {
+      expect(span.getAttribute("contenteditable")).toBe("false");
+    });
+
+    expect(span.textContent).toBe(PLACEHOLDER);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/common/EditableSpan/EditableSpan.tsx
+++ b/src/components/common/EditableSpan/EditableSpan.tsx
@@ -2,6 +2,7 @@ import {
   KeyboardEvent,
   MouseEvent,
   useEffect,
+  useLayoutEffect,
   useState,
   useRef,
 } from "react";
@@ -143,11 +144,6 @@ export const EditableSpan = ({
       e.preventDefault();
       e.stopPropagation();
       cancelRef.current = true;
-      
-      const target = e.target as HTMLElement | null;
-      if (target) {
-        target.innerText = originalTextRef.current;
-      }
       setEditing(false);
       setIsHovered(false);
       return;
@@ -183,6 +179,16 @@ export const EditableSpan = ({
 
     return classes.filter(Boolean).join(" ");
   };
+
+  // When editing ends, synchronously reset the DOM content to the text prop
+  // before the browser paints. This avoids any flash of unstyled/incorrect
+  // content that occurs when the user cancels editing (Escape), because the
+  // DOM may have been modified by contentEditable input.
+  useLayoutEffect(() => {
+    if (!editing && spanRef.current) {
+      spanRef.current.textContent = text;
+    }
+  }, [editing, text]);
 
   useEffect(() => {
     if (!autoEditToken || !isEditable) {


### PR DESCRIPTION
## Summary
- Remove `target.innerText = originalTextRef.current` from the Escape cancel path in `EditableSpan`
- Add a `useLayoutEffect` that resets `spanRef.current.textContent = text` synchronously before paint when editing ends
- Add regression tests for Escape cancellation behavior

## Root cause
When pressing Escape while editing an empty title (showing placeholder "Click to add title"), the handler directly set `target.innerText = originalTextRef.current`. While the text was correct, the element still had `contentEditable="true"` at that moment — browsers override CSS color/style for contentEditable content, so the placeholder briefly appeared as black regular text instead of gray italic.

## Fix
The Escape handler now just calls `setEditing(false)`. A `useLayoutEffect` ensures the span's `textContent` is reset to the `text` prop synchronously after the state change, before the browser paints, so no flash occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)