### PR TITLE
ci: pass -e production to wrangler deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "bun run --bun storybook build",
     "worker:dev": "bun run build:site && bun run --bun wrangler dev",
-    "worker:deploy": "bun run build:site && bun run --bun wrangler deploy",
+    "worker:deploy": "bun run build:site && bun run --bun wrangler deploy -e production",
     "worker:deploy:staging": "bun run build:site && bun run --bun wrangler deploy --env staging"
   },
   "main": "./dist/zenuml.js",


### PR DESCRIPTION
## Summary

Add `-e production` to the `worker:deploy` script in `package.json`.

## Why

The Cloudflare Worker `zenuml-web-renderer` has been **silently un-deployed since wrangler started enforcing explicit envs**. The deployed site at https://zenuml-web-renderer.zenuml.workers.dev was last bumped on **2025-11-19** despite many CD runs claiming success.

`wrangler.toml` defines both a top-level config and an `[env.production]` block. wrangler 4.x refuses to act when the CLI is invoked with no `--env` flag in this case — it prints a warning and exits 0 without uploading anything:

```
▲ [WARNING] Multiple environments are defined in the Wrangler configuration file, but no target environment was specified for the deploy command.
  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify the target environment using the `-e|--env` flag.
```

Evidence:
- Cloudflare API `accounts/.../workers/scripts/zenuml-web-renderer/versions` shows only 14 versions, latest at `2025-11-19T01:43:05Z`.
- The deploy job for the most recent CD run (https://github.com/mermaid-js/zenuml-core/actions/runs/25475806021) has only ~1.2 s between the wrangler warning and "Post job cleanup" — no upload progress, no version ID, no URL.
- Bundle hash served at the worker (`core-ySn3VwRz.js`) doesn't match any of today's CI builds.

## Fix

`wrangler deploy` → `wrangler deploy -e production`. The `[env.production]` block points to the same worker name (`zenuml-web-renderer`) as the top-level, so behaviour is unchanged once the silent-no-op is removed.

## Test plan

- [x] CI on this PR (test, playwright-tests, deploy-to-cloudflare on Node 24)
- [ ] After merge, watch the CD run on `main` for the deploy step — should now print `Total Upload`, asset count, and a worker version URL
- [ ] Verify https://zenuml-web-renderer.zenuml.workers.dev serves a build dated **today** with the new HTML title and bundle hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)