### PR TITLE
perf: gate release build artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
-        run: bun run build
+        run: bun run build:release
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
       - name: Create git tag

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "build:site": "bun run --bun vite build",
     "build:gh-pages": "bun run --bun vite build --mode gh-pages",
     "build": "bun run --bun vite build -c vite.config.lib.ts",
+    "build:release": "RELEASE=1 bun run --bun vite build -c vite.config.lib.ts",
+    "build:analyze": "RELEASE=1 ANALYZE=1 bun run --bun vite build -c vite.config.lib.ts",
     "test": "bun test src test/unit",
     "pw": "playwright test --reporter=list",
     "pw:ci": "playwright test",

--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/StylePanel.tsx
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/StylePanel.tsx
@@ -381,7 +381,7 @@ export const StylePanel = () => {
               title="Change message type"
               aria-expanded={openSubmenu === "type"}
               aria-haspopup="true"
-              onClick={() => setOpenSubmenu(openSubmenu === "type" ? null : "type")}
+              onClick={() => openSub("type")}
             >
               {messageData.current.currentType} ▾
             </button>
@@ -448,7 +448,7 @@ export const StylePanel = () => {
               title="Wrap in fragment"
               aria-expanded={openSubmenu === "wrap"}
               aria-haspopup="true"
-              onClick={() => setOpenSubmenu(openSubmenu === "wrap" ? null : "wrap")}
+              onClick={() => openSub("wrap")}
             >
               Wrap ▾
             </button>

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -20,6 +20,9 @@ const gitBranch = process.env.DOCKER
   ? ""
   : execSync("git branch --show-current").toString().trim();
 
+const isReleaseBuild = process.env.RELEASE === "1";
+const shouldAnalyzeBundle = process.env.ANALYZE === "1";
+
 // Merge all cloud-provider icon SVGs into a single chunk instead of 500+
 function manualChunks(id: string) {
   if (
@@ -45,7 +48,7 @@ export default defineConfig({
       name: "ZenUML",
       fileName: "zenuml",
     },
-    sourcemap: true,
+    sourcemap: isReleaseBuild,
     rollupOptions: {
       output: [
         {
@@ -70,12 +73,16 @@ export default defineConfig({
     svgr(),
     react(),
     cssInjectedByJsPlugin(),
-    visualizer({
-      filename: "dist/stats.html",
-      open: false,
-      gzipSize: true,
-      brotliSize: true,
-    }),
+    ...(shouldAnalyzeBundle
+      ? [
+          visualizer({
+            filename: "dist/stats.html",
+            open: false,
+            gzipSize: true,
+            brotliSize: true,
+          }),
+        ]
+      : []),
   ],
   define: {
     "process.env.NODE_ENV": '"production"',


### PR DESCRIPTION
## Summary
- Make library sourcemaps opt-in for release builds via `RELEASE=1`
- Add explicit `build:release` and `build:analyze` scripts
- Keep npm publish CI on the release build path
- Stabilize message type submenu clicks that were closing after pointer-enter opened the menu

## Test plan
- `bun eslint`
- `bun run test`
- `PORT=8080 bun pw tests/interaction/message-type-panel.spec.ts`
- `PORT=8080 bun pw`