### PR TITLE
fix: prevent dropped keystrokes when renaming a message via toolbar

### DIFF
--- a/src/components/common/EditableSpan/EditableSpan.tsx
+++ b/src/components/common/EditableSpan/EditableSpan.tsx
@@ -2,6 +2,7 @@ import {
   KeyboardEvent,
   MouseEvent,
   useEffect,
+  useLayoutEffect,
   useState,
   useRef,
 } from "react";
@@ -31,50 +32,54 @@ export const EditableSpan = ({
   const originalTextRef = useRef("");
   const spanRef = useRef<HTMLSpanElement>(null);
   const cancelRef = useRef(false);
+  const pendingFocusRef = useRef<{ x: number; y: number } | null>(null);
 
-  const focusEditable = (clickPoint?: { x: number; y: number } | null) => {
-    setTimeout(() => {
-      const target = spanRef.current;
-      if (!target) return;
+  const applyFocus = (clickPoint: { x: number; y: number } | null) => {
+    const target = spanRef.current;
+    if (!target) return;
 
-      target.focus();
+    target.focus();
 
-      if (!clickPoint) {
-        const selection = window.getSelection();
-        if (!selection) return;
-        const range = document.createRange();
-        range.selectNodeContents(target);
-        selection.removeAllRanges();
-        selection.addRange(range);
-        return;
-      }
+    const selection = window.getSelection();
+    if (!selection) return;
 
-      const selection = window.getSelection();
-      if (!selection) return;
+    if (!clickPoint) {
+      const range = document.createRange();
+      range.selectNodeContents(target);
+      selection.removeAllRanges();
+      selection.addRange(range);
+      return;
+    }
 
-      let range = document.caretRangeFromPoint?.(
+    let range = document.caretRangeFromPoint?.(clickPoint.x, clickPoint.y);
+
+    if (!range && (document as any).caretPositionFromPoint) {
+      const pos = (document as any).caretPositionFromPoint(
         clickPoint.x,
-        clickPoint.y
+        clickPoint.y,
       );
-
-      if (!range && (document as any).caretPositionFromPoint) {
-        const pos = (document as any).caretPositionFromPoint(
-          clickPoint.x,
-          clickPoint.y
-        );
-        if (pos) {
-          range = document.createRange();
-          range.setStart(pos.offsetNode, pos.offset);
-        }
+      if (pos) {
+        range = document.createRange();
+        range.setStart(pos.offsetNode, pos.offset);
       }
+    }
 
-      if (range) {
-        range.collapse(true);
-        selection.removeAllRanges();
-        selection.addRange(range);
-      }
-    }, 0);
+    if (range) {
+      range.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
   };
+
+  // Focus the span synchronously after the DOM is updated with
+  // contentEditable=true. Doing this in a layout effect (rather than a
+  // setTimeout) guarantees focus is established before any keystrokes can
+  // race against it — both for fast typists and for Playwright tests that
+  // start typing as soon as they observe contentEditable="true".
+  useLayoutEffect(() => {
+    if (!editing) return;
+    applyFocus(pendingFocusRef.current);
+  }, [editing]);
 
   const startEditing = (e: MouseEvent | KeyboardEvent) => {
     if (!isEditable) return;
@@ -83,7 +88,7 @@ export const EditableSpan = ({
 
     cancelRef.current = false;
     const target = e.target as HTMLElement | null;
-    const clickPoint =
+    pendingFocusRef.current =
       selectAllOnEdit || !("clientX" in e)
         ? null
         : { x: (e as MouseEvent).clientX, y: (e as MouseEvent).clientY };
@@ -92,7 +97,6 @@ export const EditableSpan = ({
     }
 
     setEditing(true);
-    focusEditable(clickPoint);
   };
 
   const handleClick = (e: MouseEvent) => {
@@ -197,8 +201,8 @@ export const EditableSpan = ({
     }
     originalTextRef.current = spanRef.current?.innerText ?? text;
     cancelRef.current = false;
+    pendingFocusRef.current = null;
     setEditing(true);
-    focusEditable(null);
   }, [autoEditToken, isEditable, text]);
 
   return (

--- a/tests/interaction/message-rename-panel.spec.ts
+++ b/tests/interaction/message-rename-panel.spec.ts
@@ -60,21 +60,24 @@ test.describe("Message Rename Panel", () => {
       .locator(".interaction.async .editable-span-base")
       .filter({ hasText: "Hello Bob" });
     await expect(editableLabel).toHaveAttribute("contenteditable", "true");
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const el = document.activeElement as HTMLElement | null;
+          if (!el?.classList.contains("editable-span-base")) return false;
+          return (el.textContent ?? "").includes("Hello Bob");
+        }),
+      )
+      .toBe(true);
 
     await page.keyboard.type("Hello Alice");
     await page.keyboard.press("Enter");
 
-    await expect(
-      page
-        .locator(".interaction.async .editable-span-base")
-        .filter({ hasText: "Hello Alice" })
-        .first(),
-    ).toBeVisible({ timeout: 10000 });
-    await expect(
-      page.locator('.interaction.async .message[data-selected="true"]').filter({
-        hasText: "Hello Alice",
-      }),
-    ).toHaveAttribute("data-selected", "true");
+    const renamedMessage = page
+      .locator('.interaction.async[data-source="D"][data-target="C"] .message')
+      .filter({ hasText: "Hello Alice" });
+    await expect(renamedMessage).toBeVisible({ timeout: 10000 });
+    await expect(renamedMessage).toHaveAttribute("data-selected", "true");
     await expect
       .poll(() => page.evaluate(() => (window as any).__lastContentChange ?? null))
       .toContain("D->C:Hello Alice");


### PR DESCRIPTION
## Summary
- `EditableSpan` auto-edit deferred focus via `setTimeout(0)`, so when Playwright (or a fast typist) saw `contentEditable="true"` and started typing, the first 1–2 keystrokes hit the wrong element. Result: rename "Hello Bob" → "Hello Alice" sometimes produced "llo Alice".
- Focus now runs in a `useLayoutEffect` keyed on `editing` so it lands synchronously after the DOM commit, before any keystroke can race.
- Hardened the related Playwright test: locator no longer depends on `[data-selected="true"]` (which briefly flips during re-render), and a focus-confirmation poll guards typing.

Surfaced as a Playwright flake on PR #375 ([run](https://github.com/mermaid-js/zenuml-core/actions/runs/25484666619/attempts/2)) where the screenshot showed message text "llo Alice" — proving it was a real input-race bug, not just a flaky assertion.

## Test plan
- [x] `bun run test` — 680 unit tests pass
- [x] `bun pw -- tests/interaction/message-rename-panel.spec.ts --repeat-each=10` — 30/30 pass
- [x] `bun pw -- tests/interaction` — 45/45 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)