### PR TITLE
fix: make CLI PNG browser runtime optional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,16 @@ Output formats:
 - **E2E tests**: Playwright for full integration testing with visual snapshots
 - **Test files**: Co-located with source files using `.spec.ts` extension
 
+### E2E Screenshot Snapshot Updates
+
+Never update Playwright screenshots just to make a failing snapshot test pass. Before committing any updated E2E screenshot:
+
+1. Compare the before and after screenshots and identify exactly where the visual differences are.
+2. Use the existing diagram diff workflow where applicable: run `node scripts/analyze-compare-case.mjs --case <name> --json` for structured attribution, or `--output-dir <dir>` to save `html.png`, `svg.png`, `diff.png`, and `report.json`.
+3. For compare-case pages, treat the native diff panel / analyzer output as the source of truth. Locate connected diff clusters, their bounding boxes/centroids, and the nearest semantic targets such as labels, arrows, participant boxes, participant icons, stereotypes, groups, fragments, or comments.
+4. Judge the identified differences against the actual code change in the commit. Only update snapshots when the changed pixels are an intentional and correct consequence of the code change.
+5. In the PR or commit notes, state which elements changed, where they changed, and why the screenshot update is correct.
+
 ## Key Dependencies
 
 - **React 19**: UI framework

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,6 @@
         "marked": "^4.3.0",
         "pako": "^2.1.0",
         "pino": "^8.21.0",
-        "playwright-core": "^1.59.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "tailwind-merge": "^3.4.0",
@@ -54,6 +53,7 @@
         "jsdom": "^26.1.0",
         "less": "^4.5.1",
         "pixelmatch": "^7.1.0",
+        "playwright-core": "^1.59.1",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.6",
         "prettier": "3.5.3",
@@ -71,6 +71,12 @@
       "optionalDependencies": {
         "@napi-rs/canvas": "^0.1.97",
       },
+      "peerDependencies": {
+        "playwright-core": "^1.59.1",
+      },
+      "optionalPeers": [
+        "playwright-core",
+      ],
     },
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "marked": "^4.3.0",
     "pako": "^2.1.0",
     "pino": "^8.21.0",
-    "playwright-core": "^1.59.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "tailwind-merge": "^3.4.0",
@@ -131,6 +130,7 @@
     "jsdom": "^26.1.0",
     "less": "^4.5.1",
     "pixelmatch": "^7.1.0",
+    "playwright-core": "^1.59.1",
     "pngjs": "^7.0.0",
     "postcss": "^8.5.6",
     "prettier": "3.5.3",
@@ -147,5 +147,13 @@
   },
   "optionalDependencies": {
     "@napi-rs/canvas": "^0.1.97"
+  },
+  "peerDependencies": {
+    "playwright-core": "^1.59.1"
+  },
+  "peerDependenciesMeta": {
+    "playwright-core": {
+      "optional": true
+    }
   }
 }

--- a/src/cli/zenuml.spec.ts
+++ b/src/cli/zenuml.spec.ts
@@ -18,10 +18,11 @@ const SAMPLE_DSL = "A -> B: hello";
 /** Spawn the CLI as a subprocess and collect output. */
 async function runCli(
   args: string[],
-  options?: { stdin?: string },
+  options?: { stdin?: string; env?: Record<string, string> },
 ): Promise<{ stdout: string; stderr: string; exitCode: number; stdoutBytes?: Buffer }> {
   const proc = Bun.spawn(["bun", "run", CLI_PATH, ...args], {
     cwd: resolve(import.meta.dir, "../.."),
+    env: options?.env ? { ...process.env, ...options.env } : process.env,
     stdout: "pipe",
     stderr: "pipe",
     stdin: options?.stdin !== undefined ? "pipe" : undefined,
@@ -196,6 +197,22 @@ describe("zenuml CLI", () => {
     expect(buf[1]).toBe(0x50);
     expect(buf[2]).toBe(0x4E);
     expect(buf[3]).toBe(0x47);
+  });
+
+  it("prints PNG setup guidance when Chromium cannot be launched", async () => {
+    const inputPath = tmpFile("png-missing-chromium.zenuml");
+    const outputPath = tmpFile("png-missing-chromium.png");
+    writeFileSync(inputPath, SAMPLE_DSL, "utf-8");
+
+    const { exitCode, stderr } = await runCli(["-i", inputPath, "-o", outputPath, "-e", "png"], {
+      env: { ZENUML_CHROMIUM_PATH: "/definitely/missing/chromium" },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("PNG output requires Playwright's Chromium runtime");
+    expect(stderr).toContain("npm install playwright-core");
+    expect(stderr).toContain("npx playwright-core install chromium");
+    expect(stderr).toContain("ZENUML_CHROMIUM_PATH=/path/to/chrome");
   });
 
   // (j) Auto-format detection from .png output extension (no -e flag)

--- a/src/cli/zenuml.ts
+++ b/src/cli/zenuml.ts
@@ -79,6 +79,13 @@ Examples:
   zenuml --parse -i diagram.zenuml
   zenuml -i readme.md --md
   zenuml -i readme.md --md -e png
+
+PNG output requires the optional Playwright runtime and a Chromium browser:
+  npm install playwright-core
+  npx playwright-core install chromium
+
+To use an existing Chrome/Chromium binary:
+  ZENUML_CHROMIUM_PATH=/path/to/chrome zenuml -i diagram.zenuml -o output.png
 `.trimStart();
   process.stdout.write(help);
 }
@@ -284,11 +291,44 @@ function loadConfigFile(filePath: string): Record<string, unknown> {
 /** Shared Playwright browser instance — launched once, reused across renders. */
 let _browser: Awaited<ReturnType<typeof import("playwright-core")["chromium"]["launch"]>> | null = null;
 
+function pngRuntimeHelp(detail: string): string {
+  return [
+    detail,
+    "",
+    "PNG output requires Playwright's Chromium runtime.",
+    "Install it with:",
+    "  npm install playwright-core",
+    "  npx playwright-core install chromium",
+    "",
+    "Or point ZenUML at an existing Chrome/Chromium binary:",
+    "  ZENUML_CHROMIUM_PATH=/path/to/chrome zenuml -i diagram.zenuml -o diagram.png",
+  ].join("\n");
+}
+
 async function getPlaywrightBrowser() {
   if (_browser) return _browser;
-  const { chromium } = await import("playwright-core");
-  _browser = await chromium.launch();
-  return _browser;
+  let playwright: typeof import("playwright-core");
+  try {
+    playwright = await import("playwright-core");
+  } catch (error) {
+    throw new Error(
+      pngRuntimeHelp(
+        `Cannot load optional dependency "playwright-core": ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
+  }
+
+  const executablePath = process.env["ZENUML_CHROMIUM_PATH"];
+  try {
+    _browser = await playwright.chromium.launch(executablePath ? { executablePath } : undefined);
+    return _browser;
+  } catch (error) {
+    throw new Error(
+      pngRuntimeHelp(
+        `Cannot launch Chromium${executablePath ? ` at ${executablePath}` : ""}: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
+  }
 }
 
 /** Shut down the shared browser (call before process exit). */


### PR DESCRIPTION
## Summary
- make `playwright-core` an optional peer dependency so SVG CLI installs stay light
- add clear PNG setup guidance and `ZENUML_CHROMIUM_PATH` support for existing Chrome/Chromium binaries
- document that E2E screenshot updates must be diff-attributed before committing

## Test plan
- `bun eslint`
- `bun run test`
- `bun pw`
- `bun run build:release`
- `npm pack`, install tarball into a clean temp project, verify SVG works without `playwright-core`
- verify PNG prints setup guidance without `playwright-core`
- install `playwright-core` in the temp project and verify PNG generation works