### PR TITLE
fix: guard ConditionLabel auto-edit when pending range is null

### DIFF
--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/ConditionLabel.tsx
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/ConditionLabel.tsx
@@ -9,6 +9,7 @@ import {
 import { specialCharRegex } from "@/utils/messageNormalizers";
 import { EditableSpan } from "@/components/common/EditableSpan";
 import { resolveEmojiInText } from "@/emoji/resolveEmoji";
+import { resolveAutoEditToken } from "@/utils/pendingEditableRange";
 import { useSetAtom } from "jotai";
 
 const equalityRegex = /\b(\w+)\s*==\s*(\w+)\b/g;
@@ -25,10 +26,11 @@ export const ConditionLabel = (props: { condition: any }) => {
     props.condition?.start?.start,
     props.condition?.stop?.stop,
   ];
-  const shouldAutoEdit =
-    pendingEditableRange?.start === start && pendingEditableRange?.end === end
-      ? pendingEditableRange.token
-      : undefined;
+  const shouldAutoEdit = resolveAutoEditToken(
+    pendingEditableRange,
+    start,
+    end,
+  );
 
   const handleSave = (newText: string) => {
     // if text is empty or unchanged (compare against stripped display value), bail out

--- a/src/utils/pendingEditableRange.ts
+++ b/src/utils/pendingEditableRange.ts
@@ -1,0 +1,20 @@
+export type PendingEditableRange = {
+  start: number;
+  end: number;
+  token: number;
+};
+
+/** Match pending auto-edit only when a real range is stored (see EditableLabelField). */
+export function resolveAutoEditToken(
+  pending: PendingEditableRange | null,
+  start: number | undefined,
+  end: number | undefined,
+): number | undefined {
+  if (pending == null) {
+    return undefined;
+  }
+  if (pending.start === start && pending.end === end) {
+    return pending.token;
+  }
+  return undefined;
+}

--- a/test/unit/utils/pendingEditableRange.spec.ts
+++ b/test/unit/utils/pendingEditableRange.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveAutoEditToken } from "@/utils/pendingEditableRange";
+
+describe("resolveAutoEditToken", () => {
+  it("returns undefined when pending is null and positions are undefined", () => {
+    expect(resolveAutoEditToken(null, undefined, undefined)).toBeUndefined();
+  });
+
+  it("returns token when pending range matches", () => {
+    expect(resolveAutoEditToken({ start: 1, end: 5, token: 42 }, 1, 5)).toBe(42);
+  });
+
+  it("returns undefined when range does not match", () => {
+    expect(resolveAutoEditToken({ start: 1, end: 5, token: 42 }, 2, 5)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes a rendering crash introduced in **3.47.3** (keyboard editing #369) when DSL contains an incomplete `if` (e.g. `a.m { if }`).
- `ConditionLabel` compared `pendingEditableRange?.start === start` where both sides could be `undefined` while `pendingEditableRange` was `null`, then accessed `.token` on null.
- Adds `resolveAutoEditToken()` with the same null guard already used in `EditableLabelField`, plus a unit regression test.

## Root cause

```ts
// Before: null?.start === undefined → true, then pendingEditableRange.token throws
pendingEditableRange?.start === start && pendingEditableRange?.end === end
  ? pendingEditableRange.token
  : undefined;
```

## Test plan

- [x] `bun test test/unit/utils/pendingEditableRange.spec.ts`
- [ ] Manual: render `a.m { if }` in Dynamic mode — no "ZenUML rendering error" (matches 3.43.2 / prod behavior)


Made with [Cursor](https://cursor.com)