### PR TITLE
fix(parser): guard synthesized ref() name and centralize ref label range (#305)

### DIFF
--- a/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentRef.tsx
+++ b/src/components/DiagramFrame/SeqDiagram/MessageLayer/Block/Statement/Fragment/FragmentRef.tsx
@@ -4,6 +4,7 @@ import { Numbering } from "../../../Numbering";
 import { Comment } from "../Comment/Comment";
 import { MessageLabel } from "../../../MessageLabel";
 import { syncMessageNormalizer } from "@/utils/messageNormalizers";
+import { labelRangeOfRef } from "@/parser/RefContext";
 
 export const FragmentRef = (props: {
   context: any;
@@ -15,12 +16,10 @@ export const FragmentRef = (props: {
 }) => {
   const { paddingLeft, fragmentStyle, border, leftParticipant } =
     useFragmentData(props.context, props.origin);
-  const content = props.context.ref().Content();
+  const refContext = props.context.ref();
+  const content = refContext.Content();
   const contentLabel = content?.getFormattedText();
-  const contentPosition: [number, number] = [
-    content?.start.start,
-    content?.stop.stop,
-  ];
+  const contentPosition: [number, number] = labelRangeOfRef(refContext);
 
   return (
     <div className={props.className}>

--- a/src/parser/RefContext.spec.ts
+++ b/src/parser/RefContext.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "bun:test";
+import { RootContext } from "@/parser";
+import { labelRangeOfRef } from "@/parser/RefContext";
+
+function findRef(node: any): any {
+  if (!node) return null;
+  if (typeof node.ref === "function") {
+    const r = node.ref();
+    if (r) return r;
+  }
+  const count = node.getChildCount ? node.getChildCount() : 0;
+  for (let i = 0; i < count; i++) {
+    const found = findRef(node.getChild(i));
+    if (found) return found;
+  }
+  return null;
+}
+
+function refOf(code: string): any {
+  return findRef(RootContext(code));
+}
+
+describe("RefContext.Content / labelRangeOfRef", () => {
+  it("returns the first name as content for ref(a)", () => {
+    const ref = refOf("ref(a)");
+    expect(ref.Content()).toBeTruthy();
+    expect(ref.Content().getFormattedText()).toBe("a");
+    expect(labelRangeOfRef(ref)).toEqual([4, 4]);
+  });
+
+  it("uses the first name as the label for ref(a,b,c)", () => {
+    const ref = refOf("ref(a,b,c)");
+    expect(ref.Content().getFormattedText()).toBe("a");
+    // The remaining names are participants, not part of the label.
+    expect(ref.Participants().length).toBe(2);
+    expect(labelRangeOfRef(ref)).toEqual([4, 4]);
+  });
+
+  it("handles quoted names containing whitespace", () => {
+    const ref = refOf('ref("a b")');
+    expect(ref.Content().getFormattedText()).toBe("a b");
+    expect(labelRangeOfRef(ref)).toEqual([4, 8]);
+  });
+
+  it("returns no content and a non-editable range for empty ref()", () => {
+    const ref = refOf("ref()");
+    expect(ref.Content()).toBeUndefined();
+    expect(labelRangeOfRef(ref)).toEqual([-1, -1]);
+  });
+
+  it("returns no content for ref(  ) with only whitespace (error recovery)", () => {
+    const ref = refOf("ref(  )");
+    expect(ref.Content()).toBeUndefined();
+    expect(labelRangeOfRef(ref)).toEqual([-1, -1]);
+  });
+
+  it("keeps participant detection intact for ref(someId, A, B)", () => {
+    const ref = refOf("ref(someId, A, B)");
+    expect(ref.Content().getFormattedText()).toBe("someId");
+    expect(ref.Participants().length).toBe(2);
+  });
+});

--- a/src/parser/RefContext.ts
+++ b/src/parser/RefContext.ts
@@ -3,12 +3,31 @@ import { default as sequenceParser } from "../generated-parser/sequenceParser";
 const seqParser = sequenceParser;
 const RefContext = seqParser.RefContext;
 
+// ANTLR error recovery synthesizes a NameContext for invalid input like
+// `ref()` so the `ref` rule can still match. A synthesized name has an
+// inverted token interval (stop before start) and yields empty source text;
+// it must not surface as content, an editable label, or an edit range.
+function isSynthesizedName(name: any): boolean {
+  if (!name || !name.start || !name.stop) return true;
+  return name.stop.tokenIndex < name.start.tokenIndex;
+}
+
 // @ts-expect-error -- ANTLR generated code
 RefContext.prototype.Content = function () {
-  return this.name()[0];
+  const first = this.name()[0];
+  return isSynthesizedName(first) ? undefined : first;
 };
 
 // @ts-expect-error -- ANTLR generated code
 RefContext.prototype.Participants = function () {
   return this.name().slice(1) ?? [];
 };
+
+// Inclusive [start, end] character range of a ref's first name (its label),
+// or [-1, -1] when the name is missing/synthesized so the UI renders an empty,
+// non-editable label instead of a misleading edit range.
+export function labelRangeOfRef(ctx: any): [number, number] {
+  const content = ctx?.Content?.();
+  if (!content) return [-1, -1];
+  return [content.start.start, content.stop.stop];
+}


### PR DESCRIPTION
Closes #305.

## Problem

For invalid input like `ref()`, ANTLR error recovery synthesizes a `NameContext` so the `ref` rule can still match. As a result `RefContext.Content()` returned a node with an **inverted token interval** (`stop` before `start`). That surfaced in `FragmentRef` as an empty-but-editable label with a misleading character range — `[start, stop]` where `start > stop` (e.g. `[4, 3]` for `ref()`).

## Fix

- **Harden `RefContext.prototype.Content`** to return `undefined` when the first name is missing/synthesized (detected via the inverted token interval).
- **Add `labelRangeOfRef(ctx)`** — returns an inclusive `[start, end]` range, or `[-1, -1]` when there is no real name. `-1` is already the codebase's "non-editable" signal (see the guard in `EditableLabelField.handleSave`).
- **Use the helper in `FragmentRef`** so `ref()` renders an empty, non-editable label instead of a misleading edit range.
- `Participants()` is unchanged, so participant detection / ordering is unaffected.

## Verification

- New `src/parser/RefContext.spec.ts` covers `ref(a)`, `ref(a,b,c)`, quoted names (`ref("a b")`), `ref()` + recovery, and whitespace-only `ref(  )`.
- Existing `to-collector` ref participant tests still pass (46/46).
- Parser parity gate (`parity:dualrun`) reports **0 unexplained** divergences — the change is in a derived helper, not the parse tree.
- Spot check: `FragmentRef` mounts cleanly for `ref(a)` → label `a`, `ref(SubFlow)` → label `SubFlow`, and `ref()` → just the `Ref` header (no spurious name, no runtime errors).

## Acceptance criteria (from the issue)

- [x] `ref()` produces no editable label (`labelRange [-1,-1]`) and no runtime warnings/errors at render.
- [x] Existing valid `ref(...)` labels remain unchanged.
- [x] Tests pass across the new cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dd5SLDEAjJVLNpbWg7k2et)_