### PR TITLE
fix(svg): stop stray icon tokens from creating spurious Loop fragments (#367)

### DIFF
--- a/src/svg/walkStatements.spec.ts
+++ b/src/svg/walkStatements.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "bun:test";
+import { RootContext } from "@/parser";
+import { walkStatements } from "./walkStatements";
+
+function spuriousLoops(dsl: string): number {
+  const root = RootContext(dsl) as any;
+  return walkStatements(root).filter(
+    (s) => s.kind === "fragment" && s.fragmentKind === "loop" && s.label === "",
+  ).length;
+}
+
+describe("walkStatements — stray icon tokens do not create spurious Loop fragments (#367)", () => {
+  it("icon-only if-condition: if([check]) { A.m() }", () => {
+    expect(spuriousLoops("if([check]) {\n  A.m()\n}")).toBe(0);
+  });
+
+  it("icon + participant in if-condition with icon body: if([check] a) { [rocket] }", () => {
+    expect(spuriousLoops("if([check] a) {\n  [rocket]\n}")).toBe(0);
+  });
+
+  it("icon participant with icon method: [rocket]A.[]method() {}", () => {
+    expect(spuriousLoops("[rocket]A.[]method() {}")).toBe(0);
+  });
+
+  it("still emits a real Loop fragment for a genuine while/loop", () => {
+    const root = RootContext("while(x) {\n  A.m()\n}") as any;
+    const loops = walkStatements(root).filter(
+      (s) => s.kind === "fragment" && s.fragmentKind === "loop",
+    );
+    expect(loops.length).toBe(1);
+    expect(loops[0].label).toBe("x");
+  });
+});

--- a/src/svg/walkStatements.ts
+++ b/src/svg/walkStatements.ts
@@ -142,8 +142,13 @@ function walkBlock(
       continue;
     }
 
-    // Fragments — record with enriched metadata and recurse into their blocks
+    // Fragments — record with enriched metadata and recurse into their blocks.
+    // extractFragmentInfo returns null for statements that match no known
+    // fragment type (e.g. error-recovery artifacts from stray icon tokens like
+    // `[rocket]`). The HTML renderer drops these (Statement.tsx renders nothing),
+    // so the SVG walk skips them too instead of inventing a spurious Loop (#367).
     const fragmentInfo = extractFragmentInfo(stat);
+    if (!fragmentInfo) continue;
     results.push({
       key,
       kind: "fragment",
@@ -173,7 +178,7 @@ interface FragmentExtract {
   sections: FragmentSectionInfo[];
 }
 
-function extractFragmentInfo(stat: StatNode): FragmentExtract {
+function extractFragmentInfo(stat: StatNode): FragmentExtract | null {
   // Single-block fragments: loop, opt, par, critical, section
   for (const kind of ["loop", "opt", "par", "critical", "section"] as const) {
     const frag = stat[kind]?.();
@@ -243,7 +248,10 @@ function extractFragmentInfo(stat: StatNode): FragmentExtract {
     return { fragmentKind: "ref", label, sections: [] };
   }
 
-  return { fragmentKind: "loop", label: "", sections: [] };
+  // No recognized fragment type. Rather than defaulting to a Loop fragment
+  // (which produced spurious stacked loops for stray icon tokens, issue #367),
+  // return null so the caller skips this statement — matching the HTML renderer.
+  return null;
 }
 
 function blockLength(block: BlockNode): number {


### PR DESCRIPTION
Closes #367.

## Problem

The SVG renderer created one or two stacked, empty **Loop** fragments when stray icon tokens appeared in certain positions — `if([check]) {...}`, `if([check] a) { [rocket] }`, and `[rocket]A.[]method() {}`. The HTML renderer never shows these.

## Root cause

In `src/svg/walkStatements.ts`, `extractFragmentInfo()` had a fallback that returned `{ fragmentKind: "loop", label: "", sections: [] }` for **any** statement that didn't match a known fragment type. ANTLR error-recovery artifacts produced by the stray icon tokens are statements that match no message/async/creation/return/divider/fragment type, so they hit that fallback and became spurious Loop fragments. The HTML renderer's `Statement.tsx` switch simply renders nothing for such statements.

## Fix

- `extractFragmentInfo()` now returns `null` when no recognized fragment type matches.
- `walkBlock()` skips the statement (`continue`) when it gets `null` — matching the HTML renderer, which drops unrecognized statements.

No other call sites; `extractFragmentInfo` is only used in `walkBlock`.

## Verification

- New `src/svg/walkStatements.spec.ts`: the three reported patterns now yield **0** spurious Loop fragments, and a genuine `while(x) {...}` still yields exactly **1** Loop fragment with label `x`.
- Full SVG suite green (74/74).
- Render-level spot check via `renderToSvg`: all three icon patterns produce valid SVG with **0** `Loop` fragment labels; `while(x)` still renders **1**.
- This is in the SVG renderer only — it does not touch the parse tree, so the ANTLR↔Langium parity gate is unaffected. The affected icon cases are not part of the Playwright snapshot suite.

Note: this addresses only the spurious-Loop defect. The icon-only condition parsing (`if([check])` showing an empty condition bar) is tracked separately in #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dd5SLDEAjJVLNpbWg7k2et)_