### PR TITLE
fix(ci): unblock red CI + decouple npm publish from merge (ship≠release)

### DIFF
--- a/.agents/skills/land-pr/SKILL.md
+++ b/.agents/skills/land-pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: land-pr
-description: Merge a green PR and verify the npm release succeeds. Use when the user says "merge", "land", "land PR", "merge this", "ship to npm", "merge and release", or when a PR has passed CI and is ready to merge. This is a high-stakes action — merging to main triggers an automatic npm publish, so this skill verifies everything before and after merge.
+description: Merge a green PR to main. Merging prepares a DRAFT release (it does NOT publish to npm) — publishing is a separate step via /release-app. Use when the user says "merge", "land", "land PR", "merge this", or when a PR has passed CI and is ready to merge. Verifies preconditions, picks a merge strategy, merges, and confirms the draft release was prepared.
 ---
 
 # Land PR
 
-Merge a green PR to `main` and verify the npm release. In this repo, **merge = release** — every merge to main triggers automatic npm publish via GitHub Actions. Treat this as a production deployment, not a casual merge.
+Merge a green PR to `main`. In this repo, **merge ≠ release**: merging triggers cd.yml's `draft-release` job, which prepares a draft GitHub Release. No npm publish happens here — that's `/release-app`. Merging is therefore safe to automate.
 
 ## Preconditions
 
@@ -70,51 +70,29 @@ gh pr view <PR_NUMBER> --json state
 
 Poll until state is `MERGED`. Timeout after 5 minutes — if not merged by then, report and stop.
 
-### 5. Monitor npm publish
+### 5. Confirm the draft release was prepared
 
-After merge, the `Build, Test, npm Publish, and Deploy` workflow runs on `main`. Watch it:
+After merge, the `draft-release` job runs on `main`. Watch it and confirm a fresh draft appeared:
 
 ```bash
 gh run list --repo mermaid-js/zenuml-core --branch main --limit 1 --json databaseId,status,conclusion
+# after it completes:
+gh release list --repo mermaid-js/zenuml-core --limit 10 --json tagName,isDraft,createdAt
 ```
 
-Wait for the run to complete:
-
-```bash
-gh run watch <RUN_ID> --repo mermaid-js/zenuml-core
-```
-
-### 6. Verify npm publish
-
-Check that the new version appeared on npm:
-
-```bash
-npm view @zenuml/core version
-```
-
-Compare with the version before merge. If it didn't bump, check the `npm-publish` job logs for errors.
+There should be exactly one draft release `v<version>`. That version is the next npm release — published later via `/release-app`. If no draft appears, check the `draft-release` job logs.
 
 ## Output
 
 Report one of:
 
-- **LANDED** — merged, published to npm as `@zenuml/core@<version>`
-- **MERGE BLOCKED** — which precondition failed
-- **PUBLISH FAILED** — merged but npm publish failed, with error details
-
-## On publish failure
-
-**Do NOT auto-rollback.** A failed npm publish after merge is a serious situation that needs human judgment. Report:
-
-1. The merge commit SHA
-2. The failing workflow run URL
-3. The npm-publish job error output
-4. Whether the version was partially published
-
-The user decides whether to hotfix, revert, or investigate.
+- **LANDED** — merged into main as `<squash|merge>`; draft release `v<version>` prepared (not published). Next: `/release-app`.
+- **MERGE BLOCKED** — which precondition failed.
+- **DRAFT MISSING** — merged, but the draft-release job did not produce a draft (with the job error).
 
 ## Does NOT
 
+- Publish to npm (use `/release-app`)
 - Fix CI (use `/babysit-pr`)
 - Create PRs (use `/submit-branch`)
 - Run local tests (use `/validate-branch`)

--- a/.agents/skills/release-app/SKILL.md
+++ b/.agents/skills/release-app/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: release-app
+description: Release @zenuml/core to npm by publishing the prepared draft GitHub Release. Promoting the draft triggers release.yml, which runs `npm publish --provenance`. Use when the user says "release", "release app", "publish", "publish to npm", "cut a release", "ship to npm", "release-app", or wants to promote a merged-but-unpublished change to a real npm version. This is the publish half of the ship≠release model; merging is /ship-branch.
+---
+
+# Release App (publish @zenuml/core to npm)
+
+Publish the next `@zenuml/core` version by promoting the **draft GitHub Release**
+that `/ship-branch` (merge → cd.yml `draft-release`) prepared. Publishing the
+release triggers `.github/workflows/release.yml`, which sets the version from the
+tag and runs `npm publish --provenance`.
+
+```
+draft release "v{X}"  --(this skill: publish)-->  release.yml  -->  npm publish {X}
+```
+
+## Preconditions
+
+- npm OIDC trusted publishing must be configured for `.github/workflows/release.yml`
+  on npmjs.com (see DEPLOYMENT.md). If it still points at `cd.yml`, the publish
+  job fails OIDC verification — fix the npm trusted-publisher config first.
+
+## Steps
+
+### 1. Find the fresh draft release
+
+```bash
+gh release list --repo mermaid-js/zenuml-core --limit 20 --json tagName,name,isDraft,createdAt \
+  | jq -r '.[] | select(.isDraft) | "\(.tagName)\t\(.createdAt)"'
+```
+
+- Exactly one draft `v<version>` is expected (the rolling draft kept fresh on every merge).
+- **No draft?** Nothing has been merged since the last release, or the
+  `draft-release` job failed. Ship something first (`/ship-branch`), or push to
+  main to regenerate the draft. Do not hand-create a tag.
+- Confirm the draft's target commit is the current `origin/main` HEAD:
+
+```bash
+gh release view <tag> --repo mermaid-js/zenuml-core --json targetCommitish,tagName,body
+git rev-parse origin/main
+```
+
+If the draft is stale (target ≠ current main), a newer merge should have replaced
+it — re-run after the latest `draft-release` job finishes.
+
+### 2. Review / refine release notes
+
+Show the draft's auto-generated notes. Tighten the headline changes if useful:
+
+```bash
+gh release edit <tag> --repo mermaid-js/zenuml-core --notes "<curated notes>"
+```
+
+### 3. Confirm — this is the irreversible npm publish
+
+Publishing to npm cannot be undone (only deprecated). State the version and the
+changes, and get explicit go-ahead unless the user already said "release it".
+
+### 4. Publish the release
+
+```bash
+gh release edit <tag> --repo mermaid-js/zenuml-core --draft=false --latest
+```
+
+This creates the git tag `<tag>` and fires the `release: published` event.
+
+### 5. Watch release.yml
+
+```bash
+gh run list --repo mermaid-js/zenuml-core --workflow release.yml --limit 1 --json databaseId,status
+gh run watch <RUN_ID> --repo mermaid-js/zenuml-core
+```
+
+### 6. Verify npm
+
+```bash
+npm view @zenuml/core version
+```
+
+Confirm it equals `<version>` (tag without the leading `v`). If it didn't update,
+read the `npm-publish` job logs (most likely the OIDC trusted-publisher config —
+see Preconditions).
+
+### 7. Propagate (optional)
+
+Offer `/propagate-core-release` to open downstream rollout issues for the new version.
+
+## Output
+
+```
+## Release Report
+- Published: @zenuml/core@<version>
+- Release: <release-url>
+- npm: https://www.npmjs.com/package/@zenuml/core/v/<version>
+- Propagation: <run /propagate-core-release | skipped>
+```
+
+Or:
+
+- **NO DRAFT** — nothing to publish; ship a change first.
+- **PUBLISH FAILED** — release published but `npm publish` failed, with the job
+  error (commonly the OIDC trusted-publisher filename). Do NOT auto-rollback.
+
+## Does NOT
+
+- Merge PRs (use `/ship-branch` or `/land-pr`)
+- Create the draft (that's cd.yml's `draft-release`, on merge to main)

--- a/.agents/skills/ship-branch/SKILL.md
+++ b/.agents/skills/ship-branch/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: ship-branch
-description: Ship the current branch from local validation through to npm release. Orchestrates validate-branch, submit-branch, babysit-pr, and land-pr in sequence. Use when the user says "ship", "ship it", "ship this branch", "ship to production", "release this", "get this to npm", or wants to go from local branch to published npm package in one command. Stops at the first failure with a clear report.
+description: Ship the current branch from local validation through to MERGED on main. Orchestrates validate-branch, submit-branch, babysit-pr, and land-pr in sequence. Use when the user says "ship", "ship it", "ship this branch", "merge this", or wants to go from local branch to merged in one command. Stops at merge — the npm release is a separate step via /release-app. Stops at the first failure with a clear report.
 ---
 
 # Ship Branch
 
-Orchestrate the full path from local branch to npm release. This skill composes four sub-skills in sequence, stopping at the first failure.
+Orchestrate the full path from local branch to **merged on main**. This skill composes sub-skills in sequence, stopping at the first failure.
+
+**Merging does NOT publish to npm.** Merge to main triggers cd.yml's `draft-release` job, which prepares a draft GitHub Release. Promoting that draft to a published release (which runs `npm publish`) is a separate step — use **`/release-app`** after shipping.
 
 ## Flow
 
@@ -19,10 +21,8 @@ submit-branch → FAIL → stop, report
 babysit-pr → EXHAUSTED → stop, "CI blocked"
      | GREEN
 land-pr → BLOCKED → stop, report
-     | MERGED
-land-pr → PUBLISH FAIL → alert, stop
-     | PUBLISHED
-     done
+     | MERGED (draft release prepared)
+     done → suggest /release-app to publish to npm
 ```
 
 ## Steps
@@ -54,31 +54,30 @@ Invoke `/babysit-pr` with the PR number from Step 2. If it exhausts all 3 retry 
 
 On success, the PR is green and ready to merge.
 
-### Step 4: Land and verify release
+### Step 4: Land (merge only)
 
-Merging to main triggers an npm publish — this is irreversible. To prevent the orchestrator from skipping the land-pr skill's merge strategy logic (which has happened before), **spawn an Agent** for this step:
+Merging no longer publishes to npm, so this step is safe to automate. To preserve the land-pr skill's merge-strategy logic (which the orchestrator has skipped before), **spawn an Agent** for this step:
 
 ```
 Spawn an Agent with this prompt:
 "Use the Skill tool to invoke the land-pr skill, then follow it to land PR #<PR_NUMBER>
 on mermaid-js/zenuml-core. Follow every step including the merge strategy evaluation.
-Report back the merge SHA and npm version, or the reason it was blocked."
+Report back the merge SHA and the draft release version that was prepared, or the
+reason it was blocked."
 ```
 
 Replace `<PR_NUMBER>` with the actual PR number from Step 2.
 
 Do NOT run `gh pr merge` directly from the main conversation — the land-pr skill contains merge strategy decision logic that must be evaluated by the Agent.
 
-If merge succeeds but npm publish fails, alert immediately with the failure details. Do NOT auto-rollback.
-
-On full success, report the new npm version.
+On success, report the merge SHA and the prepared draft version.
 
 ## Rules
 
 - **Each step is a hard boundary.** No step reaches back to retry a previous step.
 - **No auto-rollback.** Stop and report on any failure. The developer decides next steps.
 - **Only this skill calls babysit-pr.** Sub-skills never cross-call each other.
-- **Confirm before merge.** Since merge = npm release, pause and confirm with the user before Step 4 unless they explicitly said "ship it" (indicating full automation is intended).
+- **Ship stops at merge.** This skill does NOT publish to npm. Publishing is `/release-app`. Do not promote the draft release here.
 
 ## Output
 
@@ -90,7 +89,8 @@ Final report:
 - PR: #<number> (<url>)
 - CI: GREEN (attempt <N>)
 - Merge: <SQUASHED|MERGED> into main (<sha>)
-- npm: @zenuml/core@<version> published
+- Draft release: v<version> prepared (not yet published)
+- Next: /release-app to publish @zenuml/core@<version> to npm
 ```
 
 Or on failure:

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: land-pr
-description: Merge a green PR and verify the npm release succeeds. Use when the user says "merge", "land", "land PR", "merge this", "ship to npm", "merge and release", or when a PR has passed CI and is ready to merge. This is a high-stakes action — merging to main triggers an automatic npm publish, so this skill verifies everything before and after merge.
+description: Merge a green PR to main. Merging prepares a DRAFT release (it does NOT publish to npm) — publishing is a separate step via /release-app. Use when the user says "merge", "land", "land PR", "merge this", or when a PR has passed CI and is ready to merge. Verifies preconditions, picks a merge strategy, merges, and confirms the draft release was prepared.
 ---
 
 # Land PR
 
-Merge a green PR to `main` and verify the npm release. In this repo, **merge = release** — every merge to main triggers automatic npm publish via GitHub Actions. Treat this as a production deployment, not a casual merge.
+Merge a green PR to `main`. In this repo, **merge ≠ release**: merging triggers cd.yml's `draft-release` job, which prepares a draft GitHub Release. No npm publish happens here — that's `/release-app`. Merging is therefore safe to automate.
 
 ## Preconditions
 
@@ -70,51 +70,29 @@ gh pr view <PR_NUMBER> --json state
 
 Poll until state is `MERGED`. Timeout after 5 minutes — if not merged by then, report and stop.
 
-### 5. Monitor npm publish
+### 5. Confirm the draft release was prepared
 
-After merge, the `Build, Test, npm Publish, and Deploy` workflow runs on `main`. Watch it:
+After merge, the `draft-release` job runs on `main`. Watch it and confirm a fresh draft appeared:
 
 ```bash
 gh run list --repo mermaid-js/zenuml-core --branch main --limit 1 --json databaseId,status,conclusion
+# after it completes:
+gh release list --repo mermaid-js/zenuml-core --limit 10 --json tagName,isDraft,createdAt
 ```
 
-Wait for the run to complete:
-
-```bash
-gh run watch <RUN_ID> --repo mermaid-js/zenuml-core
-```
-
-### 6. Verify npm publish
-
-Check that the new version appeared on npm:
-
-```bash
-npm view @zenuml/core version
-```
-
-Compare with the version before merge. If it didn't bump, check the `npm-publish` job logs for errors.
+There should be exactly one draft release `v<version>`. That version is the next npm release — published later via `/release-app`. If no draft appears, check the `draft-release` job logs.
 
 ## Output
 
 Report one of:
 
-- **LANDED** — merged, published to npm as `@zenuml/core@<version>`
-- **MERGE BLOCKED** — which precondition failed
-- **PUBLISH FAILED** — merged but npm publish failed, with error details
-
-## On publish failure
-
-**Do NOT auto-rollback.** A failed npm publish after merge is a serious situation that needs human judgment. Report:
-
-1. The merge commit SHA
-2. The failing workflow run URL
-3. The npm-publish job error output
-4. Whether the version was partially published
-
-The user decides whether to hotfix, revert, or investigate.
+- **LANDED** — merged into main as `<squash|merge>`; draft release `v<version>` prepared (not published). Next: `/release-app`.
+- **MERGE BLOCKED** — which precondition failed.
+- **DRAFT MISSING** — merged, but the draft-release job did not produce a draft (with the job error).
 
 ## Does NOT
 
+- Publish to npm (use `/release-app`)
 - Fix CI (use `/babysit-pr`)
 - Create PRs (use `/submit-branch`)
 - Run local tests (use `/validate-branch`)

--- a/.claude/skills/release-app/SKILL.md
+++ b/.claude/skills/release-app/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: release-app
+description: Release @zenuml/core to npm by publishing the prepared draft GitHub Release. Promoting the draft triggers release.yml, which runs `npm publish --provenance`. Use when the user says "release", "release app", "publish", "publish to npm", "cut a release", "ship to npm", "release-app", or wants to promote a merged-but-unpublished change to a real npm version. This is the publish half of the ship≠release model; merging is /ship-branch.
+---
+
+# Release App (publish @zenuml/core to npm)
+
+Publish the next `@zenuml/core` version by promoting the **draft GitHub Release**
+that `/ship-branch` (merge → cd.yml `draft-release`) prepared. Publishing the
+release triggers `.github/workflows/release.yml`, which sets the version from the
+tag and runs `npm publish --provenance`.
+
+```
+draft release "v{X}"  --(this skill: publish)-->  release.yml  -->  npm publish {X}
+```
+
+## Preconditions
+
+- npm OIDC trusted publishing must be configured for `.github/workflows/release.yml`
+  on npmjs.com (see DEPLOYMENT.md). If it still points at `cd.yml`, the publish
+  job fails OIDC verification — fix the npm trusted-publisher config first.
+
+## Steps
+
+### 1. Find the fresh draft release
+
+```bash
+gh release list --repo mermaid-js/zenuml-core --limit 20 --json tagName,name,isDraft,createdAt \
+  | jq -r '.[] | select(.isDraft) | "\(.tagName)\t\(.createdAt)"'
+```
+
+- Exactly one draft `v<version>` is expected (the rolling draft kept fresh on every merge).
+- **No draft?** Nothing has been merged since the last release, or the
+  `draft-release` job failed. Ship something first (`/ship-branch`), or push to
+  main to regenerate the draft. Do not hand-create a tag.
+- Confirm the draft's target commit is the current `origin/main` HEAD:
+
+```bash
+gh release view <tag> --repo mermaid-js/zenuml-core --json targetCommitish,tagName,body
+git rev-parse origin/main
+```
+
+If the draft is stale (target ≠ current main), a newer merge should have replaced
+it — re-run after the latest `draft-release` job finishes.
+
+### 2. Review / refine release notes
+
+Show the draft's auto-generated notes. Tighten the headline changes if useful:
+
+```bash
+gh release edit <tag> --repo mermaid-js/zenuml-core --notes "<curated notes>"
+```
+
+### 3. Confirm — this is the irreversible npm publish
+
+Publishing to npm cannot be undone (only deprecated). State the version and the
+changes, and get explicit go-ahead unless the user already said "release it".
+
+### 4. Publish the release
+
+```bash
+gh release edit <tag> --repo mermaid-js/zenuml-core --draft=false --latest
+```
+
+This creates the git tag `<tag>` and fires the `release: published` event.
+
+### 5. Watch release.yml
+
+```bash
+gh run list --repo mermaid-js/zenuml-core --workflow release.yml --limit 1 --json databaseId,status
+gh run watch <RUN_ID> --repo mermaid-js/zenuml-core
+```
+
+### 6. Verify npm
+
+```bash
+npm view @zenuml/core version
+```
+
+Confirm it equals `<version>` (tag without the leading `v`). If it didn't update,
+read the `npm-publish` job logs (most likely the OIDC trusted-publisher config —
+see Preconditions).
+
+### 7. Propagate (optional)
+
+Offer `/propagate-core-release` to open downstream rollout issues for the new version.
+
+## Output
+
+```
+## Release Report
+- Published: @zenuml/core@<version>
+- Release: <release-url>
+- npm: https://www.npmjs.com/package/@zenuml/core/v/<version>
+- Propagation: <run /propagate-core-release | skipped>
+```
+
+Or:
+
+- **NO DRAFT** — nothing to publish; ship a change first.
+- **PUBLISH FAILED** — release published but `npm publish` failed, with the job
+  error (commonly the OIDC trusted-publisher filename). Do NOT auto-rollback.
+
+## Does NOT
+
+- Merge PRs (use `/ship-branch` or `/land-pr`)
+- Create the draft (that's cd.yml's `draft-release`, on merge to main)

--- a/.claude/skills/ship-branch/SKILL.md
+++ b/.claude/skills/ship-branch/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: ship-branch
-description: Ship the current branch from local validation through to npm release. Orchestrates validate-branch, submit-branch, babysit-pr, and land-pr in sequence. Use when the user says "ship", "ship it", "ship this branch", "ship to production", "release this", "get this to npm", or wants to go from local branch to published npm package in one command. Stops at the first failure with a clear report.
+description: Ship the current branch from local validation through to MERGED on main. Orchestrates validate-branch, submit-branch, babysit-pr, and land-pr in sequence. Use when the user says "ship", "ship it", "ship this branch", "merge this", or wants to go from local branch to merged in one command. Stops at merge — the npm release is a separate step via /release-app. Stops at the first failure with a clear report.
 ---
 
 # Ship Branch
 
-Orchestrate the full path from local branch to npm release. This skill composes four sub-skills in sequence, stopping at the first failure.
+Orchestrate the full path from local branch to **merged on main**. This skill composes sub-skills in sequence, stopping at the first failure.
+
+**Merging does NOT publish to npm.** Merge to main triggers cd.yml's `draft-release` job, which prepares a draft GitHub Release. Promoting that draft to a published release (which runs `npm publish`) is a separate step — use **`/release-app`** after shipping.
 
 ## Flow
 
@@ -19,10 +21,8 @@ submit-branch → FAIL → stop, report
 babysit-pr → EXHAUSTED → stop, "CI blocked"
      | GREEN
 land-pr → BLOCKED → stop, report
-     | MERGED
-land-pr → PUBLISH FAIL → alert, stop
-     | PUBLISHED
-     done
+     | MERGED (draft release prepared)
+     done → suggest /release-app to publish to npm
 ```
 
 ## Steps
@@ -54,31 +54,30 @@ Invoke `/babysit-pr` with the PR number from Step 2. If it exhausts all 3 retry 
 
 On success, the PR is green and ready to merge.
 
-### Step 4: Land and verify release
+### Step 4: Land (merge only)
 
-Merging to main triggers an npm publish — this is irreversible. To prevent the orchestrator from skipping the land-pr skill's merge strategy logic (which has happened before), **spawn an Agent** for this step:
+Merging no longer publishes to npm, so this step is safe to automate. To preserve the land-pr skill's merge-strategy logic (which the orchestrator has skipped before), **spawn an Agent** for this step:
 
 ```
 Spawn an Agent with this prompt:
 "Use the Skill tool to invoke the land-pr skill, then follow it to land PR #<PR_NUMBER>
 on mermaid-js/zenuml-core. Follow every step including the merge strategy evaluation.
-Report back the merge SHA and npm version, or the reason it was blocked."
+Report back the merge SHA and the draft release version that was prepared, or the
+reason it was blocked."
 ```
 
 Replace `<PR_NUMBER>` with the actual PR number from Step 2.
 
 Do NOT run `gh pr merge` directly from the main conversation — the land-pr skill contains merge strategy decision logic that must be evaluated by the Agent.
 
-If merge succeeds but npm publish fails, alert immediately with the failure details. Do NOT auto-rollback.
-
-On full success, report the new npm version.
+On success, report the merge SHA and the prepared draft version.
 
 ## Rules
 
 - **Each step is a hard boundary.** No step reaches back to retry a previous step.
 - **No auto-rollback.** Stop and report on any failure. The developer decides next steps.
 - **Only this skill calls babysit-pr.** Sub-skills never cross-call each other.
-- **Confirm before merge.** Since merge = npm release, pause and confirm with the user before Step 4 unless they explicitly said "ship it" (indicating full automation is intended).
+- **Ship stops at merge.** This skill does NOT publish to npm. Publishing is `/release-app`. Do not promote the draft release here.
 
 ## Output
 
@@ -90,7 +89,8 @@ Final report:
 - PR: #<number> (<url>)
 - CI: GREEN (attempt <N>)
 - Merge: <SQUASHED|MERGED> into main (<sha>)
-- npm: @zenuml/core@<version> published
+- Draft release: v<version> prepared (not yet published)
+- Next: /release-app to publish @zenuml/core@<version> to npm
 ```
 
 Or on failure:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,8 +45,15 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ hashFiles('bun.lock') }}
           restore-keys: playwright-browsers-
-      - name: Install Playwright Chromium for CLI PNG tests
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      # Must run on every job, even on a Playwright browser cache hit. The cache
+      # restores only the browser binary (~/.cache/ms-playwright), NOT the apt
+      # system packages that `playwright install-deps` provides. The CLI PNG tests
+      # measure text via @napi-rs/canvas, which reads system fonts through
+      # fontconfig; without those fonts it falls back to wider metrics, changing
+      # the rendered diagram width and failing the committed snapshots (which were
+      # generated with fonts present). `playwright install chromium` is a fast
+      # no-op when the binary is already cached, so this stays cheap.
+      - name: Install Playwright Chromium + system fonts for CLI PNG tests
         run: bun run pw:install
       - name: Lint
         run: bunx eslint src

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,16 +73,22 @@ jobs:
     permissions:
       contents: read
 
-  npm-publish:
+  # Merge to main PREPARES a release; it does not publish. This job computes the
+  # next version and upserts a single rolling DRAFT GitHub Release. Publishing is
+  # decoupled: promoting that draft to a published release triggers release.yml,
+  # which runs `npm publish`. Drive it with the /ship-branch (merge) and
+  # /release-app (publish) skills. See DEPLOYMENT.md.
+  draft-release:
     runs-on: ubuntu-22.04
     needs: [test, e2e]
     permissions:
-      contents: write    # for git tag push
-      id-token: write    # for npm OIDC trusted publishing
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/publish'
+      contents: write # create/delete draft releases
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # bump-version reads tags + commit history since last release
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -93,29 +99,33 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - run: bun install
-      - name: Bump Version
+      - name: Compute next version (no package.json / npm changes)
         id: bump
-        run: ./scripts/bump-version.js
+        run: ./scripts/bump-version.js --dry-run
+      - name: Upsert rolling draft release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build
-        run: bun run build:release
-      - name: Publish to npm with provenance
-        run: npm publish --provenance --access public
-      - name: Create git tag
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git tag "v${{ steps.bump.outputs.version }}"
-          git push origin "v${{ steps.bump.outputs.version }}"
-      - name: Add version to job summary
+          # Keep exactly one rolling draft for the next npm release. A draft does
+          # not create its git tag until published, so deleting stale drafts is
+          # clean. Then create a fresh draft at this commit with auto-notes.
+          gh release list --limit 100 --json tagName,isDraft \
+            | jq -r '.[] | select(.isDraft) | .tagName' \
+            | while read -r t; do
+                [ -n "$t" ] && gh release delete "$t" --yes || true
+              done
+          gh release create "v${VERSION}" \
+            --draft \
+            --title "v${VERSION}" \
+            --target "${GITHUB_SHA}" \
+            --generate-notes
+      - name: Add draft info to job summary
         run: |
-          echo "# Published Version" >> $GITHUB_STEP_SUMMARY
-          echo "| Package | Version | Tag |" >> $GITHUB_STEP_SUMMARY
-          echo "| --- | --- | --- |" >> $GITHUB_STEP_SUMMARY
-          echo "| @zenuml/core | v${{ steps.bump.outputs.version }} | [v${{ steps.bump.outputs.version }}](https://github.com/mermaid-js/zenuml-core/releases/tag/v${{ steps.bump.outputs.version }}) |" >> $GITHUB_STEP_SUMMARY
+          echo "# Draft release prepared" >> $GITHUB_STEP_SUMMARY
+          echo "Next version: **v${{ steps.bump.outputs.version }}** — draft, NOT yet published to npm." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "[View on npm](https://www.npmjs.com/package/@zenuml/core/v/${{ steps.bump.outputs.version }})" >> $GITHUB_STEP_SUMMARY
+          echo "Publish via \`/release-app\` (or publish the GitHub Release) to run \`npm publish\`." >> $GITHUB_STEP_SUMMARY
 
   # Deploy to Cloudflare Workers
   deploy-to-cloudflare:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+# Publish @zenuml/core to npm when a GitHub Release is published.
+#
+# This is the second half of the decoupled release model (the first half is the
+# `draft-release` job in cd.yml, which prepares a draft on every merge to main):
+#
+#   merge to main  -> cd.yml draft-release  -> draft GitHub Release "v{next}"
+#   publish release -> release.yml (this)    -> npm publish "{next}"
+#
+# Promote the draft with the /release-app skill (or the GitHub "Publish release"
+# button). The release tag is the source of truth for the published version.
+#
+# NOTE: npm OIDC trusted publishing is configured per workflow filename on
+# npmjs.com. When adopting this model, update the @zenuml/core trusted publisher
+# config to point at `.github/workflows/release.yml` (previously `cd.yml`),
+# otherwise `npm publish --provenance` fails OIDC verification.
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # npm OIDC trusted publishing (provenance)
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout at the release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.22
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies
+        run: bun install
+      - name: Set package.json version from release tag
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG#v}"
+          echo "Publishing @zenuml/core@${VERSION}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+      - name: Build
+        run: bun run build:release
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public
+      - name: Add version to job summary
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG#v}"
+          echo "# Published @zenuml/core@${VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- [Release ${TAG}](${{ github.event.release.html_url }})" >> $GITHUB_STEP_SUMMARY
+          echo "- [View on npm](https://www.npmjs.com/package/@zenuml/core/v/${VERSION})" >> $GITHUB_STEP_SUMMARY

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,7 +1,37 @@
 # ZenUML Web Renderer Deployment
 
 This document describes how the ZenUML demo site / web renderer is deployed to
-**Cloudflare Workers** (using Workers Static Assets, not Cloudflare Pages).
+**Cloudflare Workers** (using Workers Static Assets, not Cloudflare Pages), and
+how the `@zenuml/core` npm package is released.
+
+## npm Release Model (ship ≠ publish)
+
+Merging to `main` no longer publishes to npm. Shipping (merge) and releasing
+(publish) are decoupled, mirroring the conf-app model:
+
+```
+merge to main   -> cd.yml `draft-release`  -> draft GitHub Release "v{next}"  (NO npm publish)
+publish release -> release.yml             -> npm publish "{next}" with provenance
+```
+
+- **`draft-release`** (in `.github/workflows/cd.yml`, runs on every `main` push
+  after `test` + `e2e`): computes the next semver via `scripts/bump-version.js
+  --dry-run` and upserts a single rolling **draft** GitHub Release. Nothing is
+  published.
+- **`release.yml`** (triggered by `release: published`): checks out the release
+  tag, sets `package.json` to the tag version, builds, and runs
+  `npm publish --provenance`.
+
+Operate it with the skills: **`/ship-branch`** takes a branch to merged-on-main
+(a draft appears); **`/release-app`** promotes the draft to a published release
+(which triggers `npm publish`).
+
+> **One-time setup when adopting this model:** npm OIDC trusted publishing is
+> configured per workflow filename. Update the `@zenuml/core` trusted publisher
+> on npmjs.com to point at `.github/workflows/release.yml` (it previously pointed
+> at `cd.yml`), or `npm publish --provenance` will fail OIDC verification.
+
+## Web Renderer (Cloudflare) Deployment
 
 ## Deployment Strategy
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ bun dev
 CI/CD is done with GitHub Actions (`.github/workflows/`):
 
 - **`cd.yml`** — runs on every push and pull request: lint + unit tests (`test`),
-  Playwright E2E (`e2e`, via `e2e.yml`), then — only if both pass — publishes
-  `@zenuml/core` to npm (on `main`) and deploys the demo site to Cloudflare
-  Workers (production on `main`, staging otherwise). See [DEPLOYMENT.md](./DEPLOYMENT.md).
+  Playwright E2E (`e2e`, via `e2e.yml`), then — only if both pass — prepares a
+  **draft** release (on `main`) and deploys the demo site to Cloudflare Workers
+  (production on `main`, staging otherwise). Merging does **not** publish to npm.
+- **`release.yml`** — publishes `@zenuml/core` to npm when a GitHub Release is
+  published (i.e. when the draft is promoted). Ship with `/ship-branch` (merge),
+  release with `/release-app` (publish). See [DEPLOYMENT.md](./DEPLOYMENT.md).
 - **`e2e.yml`** — reusable Playwright workflow, called by `cd.yml` or run manually.
 - **`update-snapshots.yml`** — manually triggered; regenerates Linux visual snapshots.
 

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -93,6 +93,14 @@ const run = async () => {
   const newVersion = getNewVersion(currentVersion, versionBump);
   console.log(`New version will be: ${newVersion}`);
 
+  // Always expose the computed version to GitHub Actions, even on a dry run.
+  // The draft-release job (cd.yml) runs this with --dry-run to compute the next
+  // version for the draft tag WITHOUT mutating package.json; the version is
+  // applied at publish time (release.yml) from the release tag.
+  if (process.env.GITHUB_ACTIONS && process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${newVersion}\n`);
+  }
+
   if (!dryRun) {
     // Update package.json
     const pkg = require("../package.json");
@@ -101,13 +109,8 @@ const run = async () => {
       path.join(__dirname, "../package.json"),
       JSON.stringify(pkg, null, 2) + "\n",
     );
-
-    // Set output for GitHub Actions
-    if (process.env.GITHUB_ACTIONS) {
-      fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${newVersion}\n`);
-    }
   } else {
-    console.log("\nDRY RUN: No changes were made");
+    console.log("\nDRY RUN: package.json not modified");
   }
 };
 


### PR DESCRIPTION
Two related changes to the release pipeline. **Merging this PR does not publish to npm** (it activates the new model), so it's safe to land even though `main` is currently red.

## 1. Fix the 3-day-red CI (the blocker)

`main` has been red since 2026-06-18 — the `test` job fails on 3 CLI PNG snapshot tests with **dimension mismatches** (e.g. multi-participant 644×550 → 942×550). Root cause: the `test` job's Chromium-install step was gated on `if: cache-hit != 'true'`, but the Playwright cache only stores the browser binary, not the apt system packages. On a cache hit, `playwright install-deps` (fonts) was skipped, so `@napi-rs/canvas` measured text with fallback fonts → wider diagrams → snapshot mismatch. The committed snapshots were generated by `update-snapshots.yml`, which always installs `--with-deps`.

**Fix:** install Playwright system fonts on every `test` run (drop the cache-hit guard). No snapshots changed, no tests weakened. Verified: the `test` job is green on this PR's CI run (which hits the cache — the exact failing scenario).

Introduced by `a0762fc4` (#385, the cache-hit guard) + triggered by `16548172` (#396, first committed `-linux` snapshots).

## 2. Decouple npm publish from merge (conf-app model)

Previously **merge to main = npm publish**. Now ship and release are separate:

```
merge to main   -> cd.yml `draft-release`  -> draft GitHub Release "v{next}"  (NO npm publish)
publish release -> release.yml             -> npm publish "{next}" with provenance
```

- `cd.yml`: `npm-publish` job replaced by `draft-release` (computes next semver via `bump-version.js --dry-run`, upserts a single rolling draft).
- `release.yml`: new — on `release: published`, sets version from the tag, builds, `npm publish --provenance`.
- `bump-version.js`: `--dry-run` now emits the computed version without mutating `package.json`.
- Skills: `ship-branch` and `land-pr` reworked to stop at merge; new `release-app` promotes the draft → publish. (Mirrored in `.claude/skills` and `.agents/skills`.)
- Docs: DEPLOYMENT.md + README updated.

> **One-time setup before the first release:** update the `@zenuml/core` npm OIDC trusted publisher to point at `.github/workflows/release.yml` (was `cd.yml`), or `npm publish --provenance` fails OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
