### PR TITLE
docs(skills): align ship-branch/land-pr with Changesets, add release-app

### DIFF
--- a/.agents/skills/land-pr/SKILL.md
+++ b/.agents/skills/land-pr/SKILL.md
@@ -1,120 +1,79 @@
 ---
 name: land-pr
-description: Merge a green PR and verify the npm release succeeds. Use when the user says "merge", "land", "land PR", "merge this", "ship to npm", "merge and release", or when a PR has passed CI and is ready to merge. This is a high-stakes action — merging to main triggers an automatic npm publish, so this skill verifies everything before and after merge.
+description: Merge a green feature PR to main. Merging does NOT publish to npm — this repo uses Changesets, so merging just updates the "chore: version packages" PR. Publishing happens later via /release-app. Use when the user says "merge", "land", "land PR", "merge this", or when a PR has passed CI and is ready to merge. Verifies preconditions, picks a merge strategy, merges, and reports what was queued for release.
 ---
 
 # Land PR
 
-Merge a green PR to `main` and verify the npm release. In this repo, **merge = release** — every merge to main triggers automatic npm publish via GitHub Actions. Treat this as a production deployment, not a casual merge.
+Merge a green feature PR to `main`. In this repo **merge ≠ release** ([Changesets](https://github.com/changesets/changesets)): merging a PR that carries a `.changeset/*.md` just adds it to the **"chore: version packages"** PR that the Changesets Action maintains. Nothing publishes until that version PR is merged (`/release-app`). Merging is therefore safe to automate.
 
 ## Preconditions
 
-Before merging, verify ALL of these:
+Verify ALL before merging:
 
 1. **All CI checks green** — no pending or failed checks
 2. **No pending reviews** — no requested changes outstanding
 3. **Branch is up to date** — no merge conflicts with main
-4. **PR is the right one** — confirm PR number with the user if ambiguous
+4. **PR is the right one** — confirm the number with the user if ambiguous
 
 ```bash
 gh pr view <PR_NUMBER> --json state,mergeable,statusCheckRollup,reviewDecision
 ```
 
-If any precondition fails, report which one and stop. Do not attempt to fix — that's `babysit-pr`'s job.
+If any precondition fails, report which one and stop. Do not fix — that's `babysit-pr`'s job.
 
 ## Steps
 
 ### 1. Verify readiness
 
-Run the precondition checks above. If anything is not green, stop and report.
+Run the precondition checks. If anything is not green, stop and report.
 
 ### 2. Decide merge strategy
-
-Inspect the branch's commit history to decide between squash and merge:
 
 ```bash
 git log main..HEAD --oneline
 ```
 
-**Auto-squash if ANY of these are true:**
-- Only 1 commit on the branch
-- Commit messages contain noise patterns: "wip", "fixup", "temp", "oops", "try again", "fix lint", "fix test", duplicate messages
-- More than half the commits have the same or very similar messages
+**Auto-squash if ANY:** only 1 commit; messages contain noise ("wip", "fixup", "fix lint", duplicates); >half the commits are the same message.
 
-**Merge (preserve commits) if ALL of these are true:**
-- 2+ commits with distinct, meaningful messages
-- Each commit describes a self-contained step (not just iterations on the same change)
-- Commits follow a logical progression (e.g., "add X" → "refactor Y" → "delete Z")
+**Merge (preserve commits) if ALL:** 2+ commits with distinct, meaningful messages; each a self-contained step; logical progression.
 
-Announce the decision and why: "Squashing — 3 of 5 commits are fixups" or "Merging — 8 clean commits with distinct steps".
+Announce the decision and why. (When squashing, keep the `.changeset/*.md` file in the result — it must reach main to drive the release.)
 
 ### 3. Execute merge
 
 ```bash
-# If squash:
-gh pr merge <PR_NUMBER> --squash --auto
-
-# If merge:
-gh pr merge <PR_NUMBER> --merge --auto
+gh pr merge <PR_NUMBER> --squash --auto   # or --merge --auto
 ```
 
-Using `--auto` arms auto-merge so GitHub merges when all checks pass. If checks are already green, it merges immediately.
+`--auto` arms auto-merge; merges immediately if checks are already green.
 
 ### 4. Wait for merge
 
-If auto-merge was armed, wait for it:
-
 ```bash
-gh pr view <PR_NUMBER> --json state
+gh pr view <PR_NUMBER> --json state   # poll until MERGED; 5-min timeout
 ```
 
-Poll until state is `MERGED`. Timeout after 5 minutes — if not merged by then, report and stop.
+### 5. Report what was queued for release
 
-### 5. Monitor npm publish
-
-After merge, the `Build, Test, npm Publish, and Deploy` workflow runs on `main`. Watch it:
+After merge, the `release` job runs `changesets/action` on `main`. If the PR carried a changeset, the Action opens or updates the **"chore: version packages"** PR (it bumps versions + writes the changelog). It does NOT publish.
 
 ```bash
-gh run list --repo mermaid-js/zenuml-core --branch main --limit 1 --json databaseId,status,conclusion
+gh run list --repo mermaid-js/zenuml-core --branch main --limit 1 --json status,conclusion
+gh pr list --repo mermaid-js/zenuml-core --search "chore: version packages in:title" --json number,title,state
 ```
 
-Wait for the run to complete:
-
-```bash
-gh run watch <RUN_ID> --repo mermaid-js/zenuml-core
-```
-
-### 6. Verify npm publish
-
-Check that the new version appeared on npm:
-
-```bash
-npm view @zenuml/core version
-```
-
-Compare with the version before merge. If it didn't bump, check the `npm-publish` job logs for errors.
+If the PR had a changeset, confirm the version PR appeared/updated. If it had none (docs/CI/chore), confirm no version PR change is expected.
 
 ## Output
 
-Report one of:
-
-- **LANDED** — merged, published to npm as `@zenuml/core@<version>`
-- **MERGE BLOCKED** — which precondition failed
-- **PUBLISH FAILED** — merged but npm publish failed, with error details
-
-## On publish failure
-
-**Do NOT auto-rollback.** A failed npm publish after merge is a serious situation that needs human judgment. Report:
-
-1. The merge commit SHA
-2. The failing workflow run URL
-3. The npm-publish job error output
-4. Whether the version was partially published
-
-The user decides whether to hotfix, revert, or investigate.
+- **LANDED** — merged into main as `<squash|merge>`; release queued in the "chore: version packages" PR (#<n>). Next: `/release-app`.
+- **LANDED (no release)** — merged; no changeset, so nothing queued for publish.
+- **MERGE BLOCKED** — which precondition failed.
 
 ## Does NOT
 
+- Publish to npm (use `/release-app` — merge the version PR)
 - Fix CI (use `/babysit-pr`)
 - Create PRs (use `/submit-branch`)
 - Run local tests (use `/validate-branch`)

--- a/.agents/skills/release-app/SKILL.md
+++ b/.agents/skills/release-app/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: release-app
+description: Publish @zenuml/core to npm by merging the Changesets "chore: version packages" PR. That merge runs `changeset publish` (npm publish with provenance), tags the commit, and creates a GitHub Release. Use when the user says "release", "release app", "publish", "publish to npm", "cut a release", "ship to npm", "release-app", or wants to promote merged-but-unreleased changes to a real npm version. This is the publish half of the ship≠release model; merging feature PRs is /ship-branch.
+---
+
+# Release App (publish @zenuml/core to npm)
+
+This repo releases via [Changesets](https://github.com/changesets/changesets). The Changesets Action maintains a **"chore: version packages"** PR that accumulates every merged changeset (bumping versions + writing the changelog). **Merging that version PR is the release** — it runs `changeset publish` → `npm publish --provenance`, tags `vX.Y.Z`, and creates a GitHub Release.
+
+```
+feature PRs (each with a changeset)  --/ship-branch-->  "chore: version packages" PR
+"chore: version packages" PR  --merge (this skill)-->  npm publish + tag + GitHub Release
+```
+
+## Steps
+
+### 1. Find the version PR
+
+```bash
+gh pr list --repo mermaid-js/zenuml-core --search "chore: version packages in:title" --state open \
+  --json number,title,headRefName,url
+```
+
+- Exactly one open **"chore: version packages"** PR is expected (branch `changeset-release/main`).
+- **None?** There are no pending changesets to release. Confirm with `bun run changeset status`; if empty, ship a change with a changeset first (`/ship-branch`). Do not hand-craft a tag or version.
+
+### 2. Review the bump + changelog
+
+```bash
+gh pr view <PR_NUMBER> --repo mermaid-js/zenuml-core --json title,body
+gh pr diff <PR_NUMBER> --repo mermaid-js/zenuml-core    # version bump + CHANGELOG entries
+```
+
+Confirm the resulting version and that the changelog reads correctly. Tighten changelog wording in the changeset/PR if needed.
+
+### 3. Confirm — merging publishes to npm (irreversible)
+
+State the version that will be published and the headline changes. Get explicit go-ahead unless the user already said "release it". npm publishes cannot be undone (only deprecated).
+
+### 4. Verify the version PR is green, then merge it
+
+```bash
+gh pr view <PR_NUMBER> --repo mermaid-js/zenuml-core --json mergeable,statusCheckRollup
+gh pr merge <PR_NUMBER> --repo mermaid-js/zenuml-core --squash
+```
+
+Merging triggers the `release` job, which runs `changeset publish`.
+
+### 5. Watch the release job
+
+```bash
+gh run list --repo mermaid-js/zenuml-core --branch main --workflow cd.yml --limit 1 --json databaseId,status
+gh run watch <RUN_ID> --repo mermaid-js/zenuml-core
+```
+
+### 6. Verify npm + GitHub Release
+
+```bash
+npm view @zenuml/core version          # should equal the published version
+gh release view "v<version>" --repo mermaid-js/zenuml-core --json tagName,url
+```
+
+If npm didn't update, read the `release` job logs. (Note: `changeset publish` ships any package whose `package.json` version isn't yet on npm — keep `package.json` in sync so only changeset-driven versions publish.)
+
+### 7. Propagate (optional)
+
+Offer `/propagate-core-release` to open downstream rollout issues for the new version.
+
+## Output
+
+```
+## Release Report
+- Published: @zenuml/core@<version>
+- Version PR: #<n> (merged)
+- GitHub Release: <url>
+- npm: https://www.npmjs.com/package/@zenuml/core/v/<version>
+- Propagation: <run /propagate-core-release | skipped>
+```
+
+Or:
+
+- **NO VERSION PR** — nothing pending to release; ship a change with a changeset first.
+- **PUBLISH FAILED** — version PR merged but `npm publish` failed, with the job error. Do NOT auto-rollback.
+
+## Does NOT
+
+- Merge feature PRs (use `/ship-branch` or `/land-pr`)
+- Hand-edit versions or tags (Changesets owns versioning)

--- a/.agents/skills/ship-branch/SKILL.md
+++ b/.agents/skills/ship-branch/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ship-branch
-description: Ship the current branch from local validation through to npm release. Orchestrates validate-branch, submit-branch, babysit-pr, and land-pr in sequence. Use when the user says "ship", "ship it", "ship this branch", "ship to production", "release this", "get this to npm", or wants to go from local branch to published npm package in one command. Stops at the first failure with a clear report.
+description: Ship the current branch from local validation through to MERGED on main. Orchestrates validate-branch, submit-branch, babysit-pr, and land-pr in sequence. Use when the user says "ship", "ship it", "ship this branch", "merge this", or wants to go from local branch to merged in one command. Merging does NOT publish to npm — releases are driven by Changesets; publish via /release-app. Stops at the first failure with a clear report.
 ---
 
 # Ship Branch
 
-Orchestrate the full path from local branch to npm release. This skill composes four sub-skills in sequence, stopping at the first failure.
+Orchestrate the full path from local branch to **merged on main**. This skill composes sub-skills in sequence, stopping at the first failure.
+
+**Merging does NOT publish to npm.** This repo uses [Changesets](https://github.com/changesets/changesets). A feature PR that affects the published package carries a `.changeset/*.md`; merging it just feeds the **"chore: version packages"** PR that the Changesets Action keeps updated. Publishing happens only when that version PR is merged — use **`/release-app`**.
 
 ## Flow
 
 ```
 rebase on origin/main → CONFLICT → stop, report
      | CLEAN
+ensure changeset (if change affects published package) → MISSING → add via `bun run changeset`
+     | PRESENT or N/A
 validate-branch → FAIL → stop, report
      | PASS
 submit-branch → FAIL → stop, report
@@ -19,86 +23,80 @@ submit-branch → FAIL → stop, report
 babysit-pr → EXHAUSTED → stop, "CI blocked"
      | GREEN
 land-pr → BLOCKED → stop, report
-     | MERGED
-land-pr → PUBLISH FAIL → alert, stop
-     | PUBLISHED
-     done
+     | MERGED (version PR updated)
+     done → suggest /release-app to publish to npm
 ```
 
 ## Steps
 
 ### Step 0: Rebase on remote main
 
-Fetch and rebase onto `origin/main` to ensure the branch is up to date before validating.
-
 ```bash
 git fetch origin main
 git rebase origin/main
 ```
 
-If the rebase has conflicts, stop immediately and report. The developer must resolve conflicts manually before shipping.
+If the rebase has conflicts, stop immediately and report. Resolve manually before shipping.
 
-### Step 1: Validate locally
+### Step 1: Ensure a changeset (when the change affects the published package)
 
-Invoke `/validate-branch`. If it reports FAIL, stop and show the failure. The developer needs to fix locally before shipping.
+A fix/feature/breaking change to `@zenuml/core` needs a changeset so it gets a version bump and changelog entry:
 
-### Step 2: Submit as PR
+```bash
+bun run changeset status   # shows pending changesets + the next version
+```
 
-Invoke `/submit-branch`. If it reports FAILED, stop and show what went wrong (dirty worktree, push conflict, etc.).
+If the change is user-facing and there's no changeset, add one (`bun run changeset`, pick patch/minor/major) and commit it on the branch. Changes that don't affect the published package (CI, docs, tests, repo tooling) don't need one — note that and continue.
 
-On success, note the PR number and URL.
+### Step 2: Validate locally
 
-### Step 3: Get CI green
+Invoke `/validate-branch`. If FAIL, stop and show the failure.
 
-Invoke `/babysit-pr` with the PR number from Step 2. If it exhausts all 3 retry attempts, stop and report "CI blocked" with the babysit report.
+### Step 3: Submit as PR
 
-On success, the PR is green and ready to merge.
+Invoke `/submit-branch`. If FAILED, stop and show what went wrong. On success, note the PR number and URL.
 
-### Step 4: Land and verify release
+### Step 4: Get CI green
 
-Merging to main triggers an npm publish — this is irreversible. To prevent the orchestrator from skipping the land-pr skill's merge strategy logic (which has happened before), **spawn an Agent** for this step:
+Invoke `/babysit-pr` with the PR number. If it exhausts all 3 retry attempts, stop and report "CI blocked".
+
+### Step 5: Land (merge only)
+
+Merging no longer publishes, so this is safe to automate. To preserve the land-pr skill's merge-strategy logic (which the orchestrator has skipped before), **spawn an Agent**:
 
 ```
 Spawn an Agent with this prompt:
 "Use the Skill tool to invoke the land-pr skill, then follow it to land PR #<PR_NUMBER>
 on mermaid-js/zenuml-core. Follow every step including the merge strategy evaluation.
-Report back the merge SHA and npm version, or the reason it was blocked."
+Report back the merge SHA and whether a changeset shipped, or the reason it was blocked."
 ```
 
-Replace `<PR_NUMBER>` with the actual PR number from Step 2.
-
-Do NOT run `gh pr merge` directly from the main conversation — the land-pr skill contains merge strategy decision logic that must be evaluated by the Agent.
-
-If merge succeeds but npm publish fails, alert immediately with the failure details. Do NOT auto-rollback.
-
-On full success, report the new npm version.
+Do NOT run `gh pr merge` directly from the main conversation.
 
 ## Rules
 
-- **Each step is a hard boundary.** No step reaches back to retry a previous step.
-- **No auto-rollback.** Stop and report on any failure. The developer decides next steps.
-- **Only this skill calls babysit-pr.** Sub-skills never cross-call each other.
-- **Confirm before merge.** Since merge = npm release, pause and confirm with the user before Step 4 unless they explicitly said "ship it" (indicating full automation is intended).
+- **Each step is a hard boundary.** No step retries a previous step.
+- **No auto-rollback.** Stop and report on any failure.
+- **Only this skill calls babysit-pr.**
+- **Ship stops at merge.** This skill does NOT publish to npm. Publishing is `/release-app` (merge the "chore: version packages" PR). Do not merge the version PR here.
 
 ## Output
 
-Final report:
-
 ```
 ## Ship Report: <branch-name>
+- Changeset: <added: patch|minor|major | n/a — no package impact>
 - Validation: PASS
 - PR: #<number> (<url>)
 - CI: GREEN (attempt <N>)
 - Merge: <SQUASHED|MERGED> into main (<sha>)
-- npm: @zenuml/core@<version> published
+- Release: queued in the "chore: version packages" PR (not yet published)
+- Next: /release-app to publish to npm
 ```
 
 Or on failure:
 
 ```
 ## Ship Report: <branch-name>
-- Validation: PASS
-- PR: #<number>
 - CI: BLOCKED after 3 attempts
 - Stopped at: babysit-pr
 - Details: <failure summary>

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -1,120 +1,79 @@
 ---
 name: land-pr
-description: Merge a green PR and verify the npm release succeeds. Use when the user says "merge", "land", "land PR", "merge this", "ship to npm", "merge and release", or when a PR has passed CI and is ready to merge. This is a high-stakes action — merging to main triggers an automatic npm publish, so this skill verifies everything before and after merge.
+description: Merge a green feature PR to main. Merging does NOT publish to npm — this repo uses Changesets, so merging just updates the "chore: version packages" PR. Publishing happens later via /release-app. Use when the user says "merge", "land", "land PR", "merge this", or when a PR has passed CI and is ready to merge. Verifies preconditions, picks a merge strategy, merges, and reports what was queued for release.
 ---
 
 # Land PR
 
-Merge a green PR to `main` and verify the npm release. In this repo, **merge = release** — every merge to main triggers automatic npm publish via GitHub Actions. Treat this as a production deployment, not a casual merge.
+Merge a green feature PR to `main`. In this repo **merge ≠ release** ([Changesets](https://github.com/changesets/changesets)): merging a PR that carries a `.changeset/*.md` just adds it to the **"chore: version packages"** PR that the Changesets Action maintains. Nothing publishes until that version PR is merged (`/release-app`). Merging is therefore safe to automate.
 
 ## Preconditions
 
-Before merging, verify ALL of these:
+Verify ALL before merging:
 
 1. **All CI checks green** — no pending or failed checks
 2. **No pending reviews** — no requested changes outstanding
 3. **Branch is up to date** — no merge conflicts with main
-4. **PR is the right one** — confirm PR number with the user if ambiguous
+4. **PR is the right one** — confirm the number with the user if ambiguous
 
 ```bash
 gh pr view <PR_NUMBER> --json state,mergeable,statusCheckRollup,reviewDecision
 ```
 
-If any precondition fails, report which one and stop. Do not attempt to fix — that's `babysit-pr`'s job.
+If any precondition fails, report which one and stop. Do not fix — that's `babysit-pr`'s job.
 
 ## Steps
 
 ### 1. Verify readiness
 
-Run the precondition checks above. If anything is not green, stop and report.
+Run the precondition checks. If anything is not green, stop and report.
 
 ### 2. Decide merge strategy
-
-Inspect the branch's commit history to decide between squash and merge:
 
 ```bash
 git log main..HEAD --oneline
 ```
 
-**Auto-squash if ANY of these are true:**
-- Only 1 commit on the branch
-- Commit messages contain noise patterns: "wip", "fixup", "temp", "oops", "try again", "fix lint", "fix test", duplicate messages
-- More than half the commits have the same or very similar messages
+**Auto-squash if ANY:** only 1 commit; messages contain noise ("wip", "fixup", "fix lint", duplicates); >half the commits are the same message.
 
-**Merge (preserve commits) if ALL of these are true:**
-- 2+ commits with distinct, meaningful messages
-- Each commit describes a self-contained step (not just iterations on the same change)
-- Commits follow a logical progression (e.g., "add X" → "refactor Y" → "delete Z")
+**Merge (preserve commits) if ALL:** 2+ commits with distinct, meaningful messages; each a self-contained step; logical progression.
 
-Announce the decision and why: "Squashing — 3 of 5 commits are fixups" or "Merging — 8 clean commits with distinct steps".
+Announce the decision and why. (When squashing, keep the `.changeset/*.md` file in the result — it must reach main to drive the release.)
 
 ### 3. Execute merge
 
 ```bash
-# If squash:
-gh pr merge <PR_NUMBER> --squash --auto
-
-# If merge:
-gh pr merge <PR_NUMBER> --merge --auto
+gh pr merge <PR_NUMBER> --squash --auto   # or --merge --auto
 ```
 
-Using `--auto` arms auto-merge so GitHub merges when all checks pass. If checks are already green, it merges immediately.
+`--auto` arms auto-merge; merges immediately if checks are already green.
 
 ### 4. Wait for merge
 
-If auto-merge was armed, wait for it:
-
 ```bash
-gh pr view <PR_NUMBER> --json state
+gh pr view <PR_NUMBER> --json state   # poll until MERGED; 5-min timeout
 ```
 
-Poll until state is `MERGED`. Timeout after 5 minutes — if not merged by then, report and stop.
+### 5. Report what was queued for release
 
-### 5. Monitor npm publish
-
-After merge, the `Build, Test, npm Publish, and Deploy` workflow runs on `main`. Watch it:
+After merge, the `release` job runs `changesets/action` on `main`. If the PR carried a changeset, the Action opens or updates the **"chore: version packages"** PR (it bumps versions + writes the changelog). It does NOT publish.
 
 ```bash
-gh run list --repo mermaid-js/zenuml-core --branch main --limit 1 --json databaseId,status,conclusion
+gh run list --repo mermaid-js/zenuml-core --branch main --limit 1 --json status,conclusion
+gh pr list --repo mermaid-js/zenuml-core --search "chore: version packages in:title" --json number,title,state
 ```
 
-Wait for the run to complete:
-
-```bash
-gh run watch <RUN_ID> --repo mermaid-js/zenuml-core
-```
-
-### 6. Verify npm publish
-
-Check that the new version appeared on npm:
-
-```bash
-npm view @zenuml/core version
-```
-
-Compare with the version before merge. If it didn't bump, check the `npm-publish` job logs for errors.
+If the PR had a changeset, confirm the version PR appeared/updated. If it had none (docs/CI/chore), confirm no version PR change is expected.
 
 ## Output
 
-Report one of:
-
-- **LANDED** — merged, published to npm as `@zenuml/core@<version>`
-- **MERGE BLOCKED** — which precondition failed
-- **PUBLISH FAILED** — merged but npm publish failed, with error details
-
-## On publish failure
-
-**Do NOT auto-rollback.** A failed npm publish after merge is a serious situation that needs human judgment. Report:
-
-1. The merge commit SHA
-2. The failing workflow run URL
-3. The npm-publish job error output
-4. Whether the version was partially published
-
-The user decides whether to hotfix, revert, or investigate.
+- **LANDED** — merged into main as `<squash|merge>`; release queued in the "chore: version packages" PR (#<n>). Next: `/release-app`.
+- **LANDED (no release)** — merged; no changeset, so nothing queued for publish.
+- **MERGE BLOCKED** — which precondition failed.
 
 ## Does NOT
 
+- Publish to npm (use `/release-app` — merge the version PR)
 - Fix CI (use `/babysit-pr`)
 - Create PRs (use `/submit-branch`)
 - Run local tests (use `/validate-branch`)

--- a/.claude/skills/release-app/SKILL.md
+++ b/.claude/skills/release-app/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: release-app
+description: Publish @zenuml/core to npm by merging the Changesets "chore: version packages" PR. That merge runs `changeset publish` (npm publish with provenance), tags the commit, and creates a GitHub Release. Use when the user says "release", "release app", "publish", "publish to npm", "cut a release", "ship to npm", "release-app", or wants to promote merged-but-unreleased changes to a real npm version. This is the publish half of the ship≠release model; merging feature PRs is /ship-branch.
+---
+
+# Release App (publish @zenuml/core to npm)
+
+This repo releases via [Changesets](https://github.com/changesets/changesets). The Changesets Action maintains a **"chore: version packages"** PR that accumulates every merged changeset (bumping versions + writing the changelog). **Merging that version PR is the release** — it runs `changeset publish` → `npm publish --provenance`, tags `vX.Y.Z`, and creates a GitHub Release.
+
+```
+feature PRs (each with a changeset)  --/ship-branch-->  "chore: version packages" PR
+"chore: version packages" PR  --merge (this skill)-->  npm publish + tag + GitHub Release
+```
+
+## Steps
+
+### 1. Find the version PR
+
+```bash
+gh pr list --repo mermaid-js/zenuml-core --search "chore: version packages in:title" --state open \
+  --json number,title,headRefName,url
+```
+
+- Exactly one open **"chore: version packages"** PR is expected (branch `changeset-release/main`).
+- **None?** There are no pending changesets to release. Confirm with `bun run changeset status`; if empty, ship a change with a changeset first (`/ship-branch`). Do not hand-craft a tag or version.
+
+### 2. Review the bump + changelog
+
+```bash
+gh pr view <PR_NUMBER> --repo mermaid-js/zenuml-core --json title,body
+gh pr diff <PR_NUMBER> --repo mermaid-js/zenuml-core    # version bump + CHANGELOG entries
+```
+
+Confirm the resulting version and that the changelog reads correctly. Tighten changelog wording in the changeset/PR if needed.
+
+### 3. Confirm — merging publishes to npm (irreversible)
+
+State the version that will be published and the headline changes. Get explicit go-ahead unless the user already said "release it". npm publishes cannot be undone (only deprecated).
+
+### 4. Verify the version PR is green, then merge it
+
+```bash
+gh pr view <PR_NUMBER> --repo mermaid-js/zenuml-core --json mergeable,statusCheckRollup
+gh pr merge <PR_NUMBER> --repo mermaid-js/zenuml-core --squash
+```
+
+Merging triggers the `release` job, which runs `changeset publish`.
+
+### 5. Watch the release job
+
+```bash
+gh run list --repo mermaid-js/zenuml-core --branch main --workflow cd.yml --limit 1 --json databaseId,status
+gh run watch <RUN_ID> --repo mermaid-js/zenuml-core
+```
+
+### 6. Verify npm + GitHub Release
+
+```bash
+npm view @zenuml/core version          # should equal the published version
+gh release view "v<version>" --repo mermaid-js/zenuml-core --json tagName,url
+```
+
+If npm didn't update, read the `release` job logs. (Note: `changeset publish` ships any package whose `package.json` version isn't yet on npm — keep `package.json` in sync so only changeset-driven versions publish.)
+
+### 7. Propagate (optional)
+
+Offer `/propagate-core-release` to open downstream rollout issues for the new version.
+
+## Output
+
+```
+## Release Report
+- Published: @zenuml/core@<version>
+- Version PR: #<n> (merged)
+- GitHub Release: <url>
+- npm: https://www.npmjs.com/package/@zenuml/core/v/<version>
+- Propagation: <run /propagate-core-release | skipped>
+```
+
+Or:
+
+- **NO VERSION PR** — nothing pending to release; ship a change with a changeset first.
+- **PUBLISH FAILED** — version PR merged but `npm publish` failed, with the job error. Do NOT auto-rollback.
+
+## Does NOT
+
+- Merge feature PRs (use `/ship-branch` or `/land-pr`)
+- Hand-edit versions or tags (Changesets owns versioning)

--- a/.claude/skills/ship-branch/SKILL.md
+++ b/.claude/skills/ship-branch/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: ship-branch
-description: Ship the current branch from local validation through to npm release. Orchestrates validate-branch, submit-branch, babysit-pr, and land-pr in sequence. Use when the user says "ship", "ship it", "ship this branch", "ship to production", "release this", "get this to npm", or wants to go from local branch to published npm package in one command. Stops at the first failure with a clear report.
+description: Ship the current branch from local validation through to MERGED on main. Orchestrates validate-branch, submit-branch, babysit-pr, and land-pr in sequence. Use when the user says "ship", "ship it", "ship this branch", "merge this", or wants to go from local branch to merged in one command. Merging does NOT publish to npm — releases are driven by Changesets; publish via /release-app. Stops at the first failure with a clear report.
 ---
 
 # Ship Branch
 
-Orchestrate the full path from local branch to npm release. This skill composes four sub-skills in sequence, stopping at the first failure.
+Orchestrate the full path from local branch to **merged on main**. This skill composes sub-skills in sequence, stopping at the first failure.
+
+**Merging does NOT publish to npm.** This repo uses [Changesets](https://github.com/changesets/changesets). A feature PR that affects the published package carries a `.changeset/*.md`; merging it just feeds the **"chore: version packages"** PR that the Changesets Action keeps updated. Publishing happens only when that version PR is merged — use **`/release-app`**.
 
 ## Flow
 
 ```
 rebase on origin/main → CONFLICT → stop, report
      | CLEAN
+ensure changeset (if change affects published package) → MISSING → add via `bun run changeset`
+     | PRESENT or N/A
 validate-branch → FAIL → stop, report
      | PASS
 submit-branch → FAIL → stop, report
@@ -19,86 +23,80 @@ submit-branch → FAIL → stop, report
 babysit-pr → EXHAUSTED → stop, "CI blocked"
      | GREEN
 land-pr → BLOCKED → stop, report
-     | MERGED
-land-pr → PUBLISH FAIL → alert, stop
-     | PUBLISHED
-     done
+     | MERGED (version PR updated)
+     done → suggest /release-app to publish to npm
 ```
 
 ## Steps
 
 ### Step 0: Rebase on remote main
 
-Fetch and rebase onto `origin/main` to ensure the branch is up to date before validating.
-
 ```bash
 git fetch origin main
 git rebase origin/main
 ```
 
-If the rebase has conflicts, stop immediately and report. The developer must resolve conflicts manually before shipping.
+If the rebase has conflicts, stop immediately and report. Resolve manually before shipping.
 
-### Step 1: Validate locally
+### Step 1: Ensure a changeset (when the change affects the published package)
 
-Invoke `/validate-branch`. If it reports FAIL, stop and show the failure. The developer needs to fix locally before shipping.
+A fix/feature/breaking change to `@zenuml/core` needs a changeset so it gets a version bump and changelog entry:
 
-### Step 2: Submit as PR
+```bash
+bun run changeset status   # shows pending changesets + the next version
+```
 
-Invoke `/submit-branch`. If it reports FAILED, stop and show what went wrong (dirty worktree, push conflict, etc.).
+If the change is user-facing and there's no changeset, add one (`bun run changeset`, pick patch/minor/major) and commit it on the branch. Changes that don't affect the published package (CI, docs, tests, repo tooling) don't need one — note that and continue.
 
-On success, note the PR number and URL.
+### Step 2: Validate locally
 
-### Step 3: Get CI green
+Invoke `/validate-branch`. If FAIL, stop and show the failure.
 
-Invoke `/babysit-pr` with the PR number from Step 2. If it exhausts all 3 retry attempts, stop and report "CI blocked" with the babysit report.
+### Step 3: Submit as PR
 
-On success, the PR is green and ready to merge.
+Invoke `/submit-branch`. If FAILED, stop and show what went wrong. On success, note the PR number and URL.
 
-### Step 4: Land and verify release
+### Step 4: Get CI green
 
-Merging to main triggers an npm publish — this is irreversible. To prevent the orchestrator from skipping the land-pr skill's merge strategy logic (which has happened before), **spawn an Agent** for this step:
+Invoke `/babysit-pr` with the PR number. If it exhausts all 3 retry attempts, stop and report "CI blocked".
+
+### Step 5: Land (merge only)
+
+Merging no longer publishes, so this is safe to automate. To preserve the land-pr skill's merge-strategy logic (which the orchestrator has skipped before), **spawn an Agent**:
 
 ```
 Spawn an Agent with this prompt:
 "Use the Skill tool to invoke the land-pr skill, then follow it to land PR #<PR_NUMBER>
 on mermaid-js/zenuml-core. Follow every step including the merge strategy evaluation.
-Report back the merge SHA and npm version, or the reason it was blocked."
+Report back the merge SHA and whether a changeset shipped, or the reason it was blocked."
 ```
 
-Replace `<PR_NUMBER>` with the actual PR number from Step 2.
-
-Do NOT run `gh pr merge` directly from the main conversation — the land-pr skill contains merge strategy decision logic that must be evaluated by the Agent.
-
-If merge succeeds but npm publish fails, alert immediately with the failure details. Do NOT auto-rollback.
-
-On full success, report the new npm version.
+Do NOT run `gh pr merge` directly from the main conversation.
 
 ## Rules
 
-- **Each step is a hard boundary.** No step reaches back to retry a previous step.
-- **No auto-rollback.** Stop and report on any failure. The developer decides next steps.
-- **Only this skill calls babysit-pr.** Sub-skills never cross-call each other.
-- **Confirm before merge.** Since merge = npm release, pause and confirm with the user before Step 4 unless they explicitly said "ship it" (indicating full automation is intended).
+- **Each step is a hard boundary.** No step retries a previous step.
+- **No auto-rollback.** Stop and report on any failure.
+- **Only this skill calls babysit-pr.**
+- **Ship stops at merge.** This skill does NOT publish to npm. Publishing is `/release-app` (merge the "chore: version packages" PR). Do not merge the version PR here.
 
 ## Output
 
-Final report:
-
 ```
 ## Ship Report: <branch-name>
+- Changeset: <added: patch|minor|major | n/a — no package impact>
 - Validation: PASS
 - PR: #<number> (<url>)
 - CI: GREEN (attempt <N>)
 - Merge: <SQUASHED|MERGED> into main (<sha>)
-- npm: @zenuml/core@<version> published
+- Release: queued in the "chore: version packages" PR (not yet published)
+- Next: /release-app to publish to npm
 ```
 
 Or on failure:
 
 ```
 ## Ship Report: <branch-name>
-- Validation: PASS
-- PR: #<number>
 - CI: BLOCKED after 3 attempts
 - Stopped at: babysit-pr
 - Details: <failure summary>


### PR DESCRIPTION
Follow-up to #394 (Changesets migration). The `ship-branch` and `land-pr` skills still described the old "merge = npm publish" model, which is now wrong — merging no longer publishes.

- **ship-branch**: stops at merge; reminds to add a changeset (`bun run changeset`) for package-affecting changes; merge feeds the "chore: version packages" PR (no publish).
- **land-pr**: merge a green feature PR; reports what was queued for release; no npm publish/verification.
- **release-app** (new): the release = merging the "chore: version packages" PR → `changeset publish` → npm + tag + GitHub Release. Preserves the ship(merge)/release(publish) two-verb model.

Mirrored in both `.claude/skills/` and `.agents/skills/`. Docs-only — no changeset (skills aren't part of the published package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)