### PR TITLE
feat(parser): headless reentrant validate()/parse() at @zenuml/core/parser subpath

### DIFF
--- a/.changeset/headless-parser-subpath.md
+++ b/.changeset/headless-parser-subpath.md
@@ -1,0 +1,7 @@
+---
+"@zenuml/core": minor
+---
+
+Add a headless `@zenuml/core/parser` subpath exporting reentrant `validate(code)` and `parse(code)`.
+
+Unlike the default entry (a browser/DOM bundle that throws `location is not defined` in Node), this subpath imports cleanly server-side and is reentrant — each call uses its own error listener instead of the shared module-level `Errors`/`ErrorDetails`, so it is safe to call repeatedly or concurrently. `validate` returns `{ pass, errorDetails }`; `parse` additionally returns the error-recovered `rootContext` tree.

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "build:lsp:worker": "bun run --bun vite build -c vite.config.lsp-worker.ts",
     "build:lsp": "bun run build:lsp:node && bun run build:lsp:worker",
     "lsp": "bun src/parser-langium/lsp/main.ts --stdio",
-    "build": "bun run build:lib && bun run build:cli",
-    "build:release": "RELEASE=1 bun run build:lib && RELEASE=1 bun run build:cli && RELEASE=1 bun run build:lsp",
-    "build:analyze": "RELEASE=1 ANALYZE=1 bun run build:lib && RELEASE=1 bun run build:cli",
+    "build:parser": "bun run --bun vite build -c vite.config.parser.ts",
+    "build": "bun run build:lib && bun run build:cli && bun run build:parser",
+    "build:release": "RELEASE=1 bun run build:lib && RELEASE=1 bun run build:cli && RELEASE=1 bun run build:lsp && RELEASE=1 bun run build:parser",
+    "build:analyze": "RELEASE=1 ANALYZE=1 bun run build:lib && RELEASE=1 bun run build:cli && RELEASE=1 bun run build:parser",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "release": "bun run build:release && changeset publish",
@@ -80,7 +81,17 @@
       }
     },
     "./lsp-worker": "./dist/lsp/zenuml-server.worker.js",
-    "./lsp-server": "./dist/lsp/main.js"
+    "./lsp-server": "./dist/lsp/main.js",
+    "./parser": {
+      "import": {
+        "types": "./types/parser/index.d.ts",
+        "default": "./dist/parser/index.mjs"
+      },
+      "require": {
+        "types": "./types/parser/index.d.ts",
+        "default": "./dist/parser/index.cjs"
+      }
+    }
   },
   "engines": {
     "node": ">=20"

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -31,6 +31,21 @@ class SeqErrorListener extends antlr4.error.ErrorListener {
   }
 }
 
+// Reentrant error listener: collects syntax errors into its OWN instance array
+// instead of the shared module-level `errors`/`errorDetails`. This is what lets
+// validate()/parse() below run repeatedly or concurrently (e.g. server-side)
+// without the clear-before/clear-after dance the legacy globals require.
+class CollectingErrorListener extends antlr4.error.ErrorListener {
+  constructor() {
+    super();
+    /** @type {{ line: number, column: number, msg: string }[]} */
+    this.errorDetails = [];
+  }
+  syntaxError(recognizer, offendingSymbol, line, column, msg) {
+    this.errorDetails.push({ line, column, msg });
+  }
+}
+
 function createParser(code, { silent = false } = {}) {
   const chars = new antlr4.InputStream(code);
   const lexer = new sequenceLexer(chars);
@@ -105,6 +120,43 @@ antlr4.ParserRuleContext.prototype.getComment = function () {
   );
 };
 
+/**
+ * Parse ZenUML DSL with a per-call (reentrant) error listener and return both
+ * the error-recovered parse tree and a structured error list. Safe to call
+ * repeatedly/concurrently — it does not touch the module-level Errors/ErrorDetails.
+ *
+ * @param {string} code ZenUML DSL source
+ * @returns {{ rootContext: object, pass: boolean, errorDetails: { line: number, column: number, msg: string }[] }}
+ */
+export function parse(code) {
+  const listener = new CollectingErrorListener();
+  const chars = new antlr4.InputStream(code);
+  const lexer = new sequenceLexer(chars);
+  lexer.removeErrorListeners();
+  lexer.addErrorListener(listener);
+  const tokens = new antlr4.CommonTokenStream(lexer);
+  const parser = new sequenceParser(tokens);
+  parser.removeErrorListeners();
+  parser.addErrorListener(listener);
+  const tree = parser.prog();
+  return {
+    rootContext: tree,
+    pass: listener.errorDetails.length === 0,
+    errorDetails: listener.errorDetails,
+  };
+}
+
+/**
+ * Validate ZenUML DSL syntax without exposing the parse tree. Reentrant.
+ *
+ * @param {string} code ZenUML DSL source
+ * @returns {{ pass: boolean, errorDetails: { line: number, column: number, msg: string }[] }}
+ */
+export function validate(code) {
+  const { pass, errorDetails } = parse(code);
+  return { pass, errorDetails };
+}
+
 export const ProgContext = sequenceParser.ProgContext;
 export const RootContext = rootContext;
 export const GroupContext = sequenceParser.GroupContext;
@@ -127,6 +179,8 @@ export default {
     const toCollector = ToCollector;
     return toCollector.getParticipants(ctx);
   },
+  parse,
+  validate,
   Errors: errors,
   ErrorDetails: errorDetails,
   /**

--- a/src/parser/validate.spec.ts
+++ b/src/parser/validate.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import Parser, { parse, validate } from "@/parser";
+
+const VALID = "A.method() {\n  B.reply()\n}";
+const INVALID = "A.method() {\n  @@@ ))) {{{\n";
+
+describe("reentrant parser API: validate()", () => {
+  it("passes valid ZenUML with no error details", () => {
+    const result = validate(VALID);
+    expect(result.pass).toBe(true);
+    expect(result.errorDetails).toEqual([]);
+  });
+
+  it("fails invalid ZenUML with structured {line, column, msg} errors", () => {
+    const result = validate(INVALID);
+    expect(result.pass).toBe(false);
+    expect(result.errorDetails.length).toBeGreaterThan(0);
+    const first = result.errorDetails[0];
+    expect(typeof first.line).toBe("number");
+    expect(typeof first.column).toBe("number");
+    expect(typeof first.msg).toBe("string");
+  });
+
+  it("is reentrant: a valid parse after an invalid one carries no stale errors", () => {
+    expect(validate(INVALID).pass).toBe(false);
+    const after = validate(VALID);
+    expect(after.pass).toBe(true);
+    expect(after.errorDetails).toEqual([]);
+  });
+
+  it("does NOT mutate the legacy module-global ErrorDetails (independent per-call state)", () => {
+    Parser.ErrorDetails.length = 0;
+    validate(INVALID);
+    expect(Parser.ErrorDetails.length).toBe(0);
+  });
+});
+
+describe("reentrant parser API: parse()", () => {
+  it("returns a parse tree plus pass/errorDetails for valid input", () => {
+    const result = parse(VALID);
+    expect(result.pass).toBe(true);
+    expect(result.errorDetails).toEqual([]);
+    expect(result.rootContext).toBeTruthy();
+  });
+
+  it("returns a recovered tree and errors for invalid input", () => {
+    const result = parse(INVALID);
+    expect(result.pass).toBe(false);
+    expect(result.errorDetails.length).toBeGreaterThan(0);
+    // ANTLR error recovery still yields a tree; we expose it for callers that want it.
+    expect(result.rootContext).toBeTruthy();
+  });
+});

--- a/types/parser/index.d.ts
+++ b/types/parser/index.d.ts
@@ -1,0 +1,37 @@
+/**
+ * `@zenuml/core/parser` — headless, server-safe ANTLR parsing/validation for
+ * ZenUML DSL. Unlike the default `@zenuml/core` entry (a browser/DOM bundle),
+ * this subpath imports cleanly in Node and is reentrant (safe to call
+ * repeatedly/concurrently — it does not touch any shared module state).
+ */
+
+export interface ErrorDetail {
+  /** 1-based line of the offending token. */
+  line: number;
+  /** 0-based column of the offending token. */
+  column: number;
+  /** ANTLR diagnostic message. */
+  msg: string;
+}
+
+export interface ParseResult {
+  /** True when the DSL parsed with no syntax errors. */
+  pass: boolean;
+  /** Structured syntax errors (empty when `pass` is true). */
+  errorDetails: ErrorDetail[];
+}
+
+export interface ParseTreeResult extends ParseResult {
+  /**
+   * ANTLR `ProgContext` parse tree. ANTLR error recovery still produces a
+   * best-effort tree even when `pass` is false, so this is generally present.
+   * Typed as `unknown` — cast to the ANTLR context type if you walk it.
+   */
+  rootContext: unknown;
+}
+
+/** Validate ZenUML DSL syntax without exposing the parse tree. */
+export declare function validate(code: string): ParseResult;
+
+/** Parse ZenUML DSL, returning the error-recovered tree plus structured errors. */
+export declare function parse(code: string): ParseTreeResult;

--- a/vite.config.parser.ts
+++ b/vite.config.parser.ts
@@ -1,0 +1,31 @@
+/* eslint-env node */
+import { resolve } from "path";
+import { defineConfig } from "vite";
+
+// Headless parser build: bundles the DOM-free ANTLR parser layer
+// (`src/parser/index.js`) into a Node-safe ESM + CJS module published at the
+// `@zenuml/core/parser` subpath. The main `.` entry (`src/core.tsx`) pulls in
+// the React/DOM renderer and cannot be imported server-side; this entry can.
+// `antlr4` stays external so consumers resolve it from their own node_modules.
+export default defineConfig({
+  build: {
+    target: "esnext",
+    lib: {
+      entry: resolve(__dirname, "src/parser/index.js"),
+      formats: ["es", "cjs"],
+      fileName: (format) => (format === "es" ? "index.mjs" : "index.cjs"),
+    },
+    outDir: "dist/parser",
+    emptyOutDir: true,
+    copyPublicDir: false,
+    sourcemap: process.env.RELEASE === "1",
+    rollupOptions: {
+      external: ["antlr4"],
+    },
+  },
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## What

Adds a new **`@zenuml/core/parser`** subpath exposing two reentrant, DOM-free functions for server-side ZenUML validation:

```ts
import { validate, parse } from "@zenuml/core/parser";
validate(code) // → { pass: boolean, errorDetails: { line, column, msg }[] }
parse(code)    // → { rootContext, pass, errorDetails }   (rootContext = error-recovered ANTLR tree)
```

## Why

The default `@zenuml/core` entry is a browser/DOM bundle — importing it in Node throws `location is not defined`, and it doesn't expose the parser. So there's been no way to validate ZenUML DSL server-side (needed by diagramly's AI diagram-repair path, which otherwise can't tell a real fix from a no-op for sequence diagrams).

The parser layer itself is already DOM-free and runs headless (the `zenuml --check` CLI proves it). This PR just makes it reachable as a published subpath.

## Design notes

- **Reentrant.** The legacy module-level `Errors`/`ErrorDetails` arrays are shared mutable state — callers (incl. `ZenUml.parse()`) must `.length = 0` them before *and* after each call, which races under concurrency. `validate`/`parse` use a per-call `CollectingErrorListener` instead, so they're safe to call repeatedly/concurrently.
- **`rootContext` is untouched** — left byte-identical to `main` so the `parser-langium` `compat.ts` mirror (and its documented `_syntaxErrors`-before-`prog()` contract) is unaffected.
- **ANTLR-backed**, matching the current rendering parser (`core.tsx`/`Store.ts` still use `RootContext`). The `{ pass, errorDetails }` shape maps cleanly onto Langium's `parseZen` `lexerErrors`/`parserErrors`, so the internals can flip to Langium at Stage 6 without changing the public contract.
- Build: `vite.config.parser.ts` emits `dist/parser/index.{mjs,cjs}` (antlr4 external), wired into `build`/`build:release`. Hand-written `types/parser/index.d.ts`. Changeset included (minor).

## Verification

- New `src/parser/validate.spec.ts` (6 tests): valid→pass, invalid→structured errors, reentrancy (no stale errors, doesn't touch the global arrays), `parse` returns a tree.
- Full `bun test src/parser` green for all ANTLR specs.
- Built bundle imported in **plain `node`** (no DOM): valid→`{pass:true}`, invalid→`pass:false` with `{line,column,msg}` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)