### PR TITLE
chore: stop publishing demo-site assets in the npm package

### DIFF
--- a/.changeset/package-hygiene-copy-public-dir.md
+++ b/.changeset/package-hygiene-copy-public-dir.md
@@ -1,0 +1,5 @@
+---
+"@zenuml/core": patch
+---
+
+Stop publishing demo-site assets in the npm package. The library build was copying `public/` (vendored codemirror/highlightjs/tailwind, demo HTML, `CNAME.txt`, `favicon.ico`, and a proprietary `MS Sans Serif.ttf`) into `dist/`. Set `copyPublicDir: false` on `vite.config.lib.ts` to match the cli/parser/lsp build configs; the demo site build (`vite.config.ts`) is unaffected and still ships its public assets.

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -40,6 +40,10 @@ function manualChunks(id: string) {
 export default defineConfig({
   build: {
     target: "esnext",
+    // Don't rake the demo site's public/ (fonts, vendor/, demo html, CNAME) into
+    // the published package — matches cli/parser/lsp configs. build:site uses
+    // vite.config.ts, which is unaffected and still ships public assets.
+    copyPublicDir: false,
     // https://vitejs.dev/guide/build.html#library-mode
     lib: {
       entry: resolve(__dirname, "src/core.tsx"),


### PR DESCRIPTION
## What

`vite.config.lib.ts` was missing `copyPublicDir: false`, so the library build raked the demo site's `public/` directory into `dist/` — which the published npm package then shipped (`files: ["dist/", "types/"]`).

Debris that was shipping to every consumer:
- `dist/fonts/MS Sans Serif.ttf` — a **proprietary Microsoft font** redistributed inside an MIT package
- `dist/vendor/{codemirror,highlightjs,tailwindcss}/*` — stale vendored copies (supply-chain noise)
- `dist/embed-container-demo.html`, `dist/test-chinese.html`, `dist/CNAME.txt`, `dist/favicon.ico`, `dist/vite.svg`

## Fix

One line: `copyPublicDir: false` on the lib build — matching what the `cli`, `parser`, `lsp`, and `lsp-worker` configs already do. Only `vite.config.lib.ts` was missing it.

## Verification

Rebuilt `bun run build:lib`; `dist/` now contains only `zenuml.esm.mjs`, `zenuml.js`, and the `cloud-icons` chunk — none of the demo debris.

The demo-site build (`vite.config.ts` / `build:site`) is unaffected and still ships `public/` assets to GitHub Pages / Cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)