### PR TITLE
refactor(parser): freeze @zenuml/core/parser subpath to validate/parse (N1)

### DIFF
--- a/.changeset/freeze-parser-subpath.md
+++ b/.changeset/freeze-parser-subpath.md
@@ -1,0 +1,7 @@
+---
+"@zenuml/core": minor
+---
+
+Narrow the `@zenuml/core/parser` subpath to its documented public surface: `validate()` and `parse()` only. The built bundle previously also exported `RootContext`, `ProgContext`, `GroupContext`, `ParticipantContext`, `Participants`, `Depth`, and a default object — none of which were declared in `types/parser/index.d.ts`, so no typed consumer could reference them. These ANTLR-internal helpers are now kept in-repo (`src/parser/index.js`) and no longer leak into the package contract; the subpath entry is a thin `src/parser/public.ts`.
+
+Also corrected the subpath's type docs, which claimed it "does not touch any shared module state" — importing it applies ZenUML's ANTLR prototype augmentation to the shared `antlr4` package as a one-time, import-time side effect. This is now documented honestly.

--- a/src/parser/public.ts
+++ b/src/parser/public.ts
@@ -1,0 +1,14 @@
+/**
+ * Public entry for the `@zenuml/core/parser` subpath.
+ *
+ * Deliberately re-exports ONLY `validate()` and `parse()` — the surface the
+ * published `types/parser/index.d.ts` declares. `./index` also exports several
+ * ANTLR-internal helpers (`RootContext`, `ProgContext`, `Participants`, …) for
+ * in-repo use, but those are implementation detail and must not leak into the
+ * package's public contract.
+ *
+ * Importing this module (transitively via `./index`) applies ZenUML's ANTLR
+ * prototype augmentation to the shared `antlr4` package as a one-time,
+ * import-time side effect; the `validate`/`parse` calls themselves are reentrant.
+ */
+export { parse, validate } from "./index";

--- a/types/parser/index.d.ts
+++ b/types/parser/index.d.ts
@@ -1,8 +1,15 @@
 /**
  * `@zenuml/core/parser` — headless, server-safe ANTLR parsing/validation for
  * ZenUML DSL. Unlike the default `@zenuml/core` entry (a browser/DOM bundle),
- * this subpath imports cleanly in Node and is reentrant (safe to call
- * repeatedly/concurrently — it does not touch any shared module state).
+ * this subpath imports cleanly in Node, and `validate`/`parse` are reentrant:
+ * each call builds its own lexer/parser/error listener, so calls are safe to
+ * make repeatedly and concurrently.
+ *
+ * Import-time side effect: loading this module applies ZenUML's ANTLR prototype
+ * augmentation (methods such as `getFormattedText` are patched onto
+ * `antlr4.ParserRuleContext.prototype`). This is a one-time, process-wide
+ * mutation of the `antlr4` package you have installed — harmless on its own,
+ * but relevant if another library in the same process also depends on `antlr4`.
  */
 
 export interface ErrorDetail {

--- a/vite.config.parser.ts
+++ b/vite.config.parser.ts
@@ -2,16 +2,19 @@
 import { resolve } from "path";
 import { defineConfig } from "vite";
 
-// Headless parser build: bundles the DOM-free ANTLR parser layer
-// (`src/parser/index.js`) into a Node-safe ESM + CJS module published at the
-// `@zenuml/core/parser` subpath. The main `.` entry (`src/core.tsx`) pulls in
-// the React/DOM renderer and cannot be imported server-side; this entry can.
+// Headless parser build: bundles the DOM-free ANTLR parser layer into a
+// Node-safe ESM + CJS module published at the `@zenuml/core/parser` subpath.
+// The main `.` entry (`src/core.tsx`) pulls in the React/DOM renderer and
+// cannot be imported server-side; this entry can.
+// The entry is `src/parser/public.ts` (not `index.js`) so the published bundle
+// exports ONLY `validate`/`parse` — matching `types/parser/index.d.ts` — instead
+// of also leaking `index.js`'s in-repo ANTLR helpers into the public contract.
 // `antlr4` stays external so consumers resolve it from their own node_modules.
 export default defineConfig({
   build: {
     target: "esnext",
     lib: {
-      entry: resolve(__dirname, "src/parser/index.js"),
+      entry: resolve(__dirname, "src/parser/public.ts"),
       formats: ["es", "cjs"],
       fileName: (format) => (format === "es" ? "index.mjs" : "index.cjs"),
     },


### PR DESCRIPTION
## Why (audit finding N1)

The `@zenuml/core/parser` subpath (added in #410) had two defects:
1. **Runtime exported 9 symbols; the `.d.ts` declared 2.** The built bundle exported `RootContext`, `ProgContext`, `GroupContext`, `ParticipantContext`, `Participants`, `Depth`, and a default object — none in `types/parser/index.d.ts`. Undocumented exports are a semver trap for JS consumers who discover them.
2. **The `.d.ts` claimed the subpath "does not touch any shared module state"** — false: importing it mutates `antlr4.ParserRuleContext.prototype` (a process-wide side effect).

We confirmed **no internal project** uses the subpath (conf-app/web-sequence/etc. are on 3.x; zero imports of `@zenuml/core/parser` anywhere in our repos), so narrowing is internally safe.

## What

- New thin entry `src/parser/public.ts` re-exporting **only** `validate` and `parse`; `vite.config.parser.ts` points at it. `src/parser/index.js` keeps its full export list for in-repo use — the ANTLR-internal helpers simply no longer leak into the package.
- Corrected the `.d.ts` docs: kept the (verified) reentrancy claim — `validate`/`parse` build a per-call lexer/parser/listener — and replaced the false "no shared state" line with honest documentation of the import-time `antlr4` prototype augmentation.

## Verification

- Built `dist/parser/index.mjs` now exports **exactly `parse, validate`** (no default), verified by importing the built bundle; `validate`/`parse` still function (augmentation side-effects survive tree-shaking — `parse` returns a real tree).
- `bun run typecheck` → 0 errors; `bun run test` → 1638 pass / 0 fail.
- Parse logic is byte-identical (only the entry changed), so `validate`/`parse` behavior is unchanged.

Changeset: **minor** — narrows a one-release-old subpath to its documented surface; the removed exports were never typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)