### PR TITLE
refactor(parser): enforce the v1 IR contract (satisfies ParserModule) + reconcile drift (N2)

### DIFF
--- a/.changeset/enforce-ir-contract.md
+++ b/.changeset/enforce-ir-contract.md
@@ -1,0 +1,12 @@
+---
+"@zenuml/core": patch
+---
+
+Enforce the v1 IR contract (`src/parser/ir/contract.ts`) instead of just documenting it. `src/parser-langium/compat.ts` now binds its module surface to `ParserModule` with `satisfies`, so the CI typecheck gate fails if the Langium facade drifts from the contract (including the ProgContext/GroupContext/ParticipantContext facade classes and the ParticipantsCollection shape, checked transitively).
+
+Wiring this surfaced three real contract-vs-reality drifts, now reconciled (all internal, no consumer-facing behavior change):
+- `IrNode.stop` was `TokenView` but ANTLR (and the facade) give zero-token rules `stop === null` — corrected to `TokenView | null`.
+- The `Participant` class marked renderer-facing fields (`type`, `stereotype`, `color`, …) `private` while exposing them via `ToValue()`; made them public to match `ParticipantView` (compile-time only).
+- `ParticipantsCollection.GetPositions`/`GetAssigneePositions` claimed `IrPosition[]` but return `Set | undefined` (the consumer normalizes with `Array.from(… ?? [])`) — corrected the contract.
+
+Also corrected the contract header, which falsely claimed the facade classes `implements` these interfaces.

--- a/src/parser-langium/compat.ts
+++ b/src/parser-langium/compat.ts
@@ -13,6 +13,7 @@
  *  - sub-rule fixture entries are rebuilt on parseZen(code, { rule }).
  */
 import type { ParseResult } from "langium";
+import type { ParserModule } from "@/parser/ir/contract";
 import { parseZen } from "./services";
 import {
   buildRootFacade,
@@ -124,6 +125,12 @@ export const DividerContextFixture = fixture("Divider");
 export const CreationContextFixture = fixture("Creation");
 export const RetContextFixture = fixture("Ret");
 
+// `satisfies ParserModule` binds this facade's module surface to the v1 IR
+// contract (src/parser/ir/contract.ts). tsc (the CI typecheck gate) now fails
+// if the facade drifts from the contract — including the ProgContext /
+// GroupContext / ParticipantContext facade classes, which ParserModule types
+// as `ContextClass<...>` and so are checked transitively against their
+// contract node interfaces.
 const compatDefault = {
   RootContext,
   ProgContext,
@@ -133,6 +140,6 @@ const compatDefault = {
   Errors,
   ErrorDetails,
   Depth,
-};
+} satisfies ParserModule;
 
 export default compatDefault;

--- a/src/parser/Participants.ts
+++ b/src/parser/Participants.ts
@@ -35,17 +35,21 @@ export const blankParticipant = {
 
 export class Participant {
   name: string;
-  private stereotype: string | undefined;
+  // Fields the renderer-facing ParticipantView (ir/contract.ts) exposes are
+  // public; they were already fully exposed via ToValue(), so the previous
+  // `private` was inconsistent encapsulation. `width` stays private — it is not
+  // part of ParticipantView.
+  stereotype: string | undefined;
   private width: number | undefined;
-  private groupId: number | string | undefined;
+  groupId: number | string | undefined;
   explicit: boolean | undefined;
   isStarter: boolean | undefined;
   label: string | undefined;
-  private type: string | undefined;
-  private color: string | undefined;
-  private comment: string | undefined;
-  private assignee: string | undefined;
-  private emoji: string | undefined;
+  type: string | undefined;
+  color: string | undefined;
+  comment: string | undefined;
+  assignee: string | undefined;
+  emoji: string | undefined;
   positions: Set<Position> = new Set();
   assigneePositions: Set<Position> = new Set();
 

--- a/src/parser/ir/contract.ts
+++ b/src/parser/ir/contract.ts
@@ -6,8 +6,12 @@
  * `src/utils`) consumes today. It contains TypeScript types ONLY — no runtime
  * code, and no imports from `antlr4`, `langium`, or `src/generated-parser`.
  *
- * The Stage-3 Langium compatibility facade classes `implements` these
- * interfaces; the renderer stays untouched through the migration
+ * Enforcement: `src/parser-langium/compat.ts` binds its module surface to
+ * {@link ParserModule} with `satisfies`, so `tsc` (the CI typecheck gate) fails
+ * if the Langium facade drifts from this contract — including the ProgContext /
+ * GroupContext / ParticipantContext facade classes and the ParticipantsCollection
+ * shape, which ParserModule types as members and so are checked transitively.
+ * The renderer stays untouched through the migration
  * (docs/langium-migration/07-risk-map.md Part 3). The contract is derived from:
  *
  * - docs/langium-migration/03-context-api-contract.md (per-method consumer table)
@@ -128,8 +132,13 @@ export interface IrNode {
    * Last token of the node. `stop.stop` is INCLUSIVE — every label-edit /
    * DSL-transform site computes `stop.stop + 1` for the exclusive slice end.
    * Consumers: same set as {@link IrNode.start}.
+   *
+   * `null` when the node consumed zero parser-visible tokens (ANTLR gives such
+   * a rule `stop === null`; the Langium facade mirrors this — facade/nodes.ts
+   * `get stop()`). The DSL-transform consumers above only read `stop` on
+   * non-empty nodes, so they never observe the `null`.
    */
-  readonly stop: TokenView;
+  readonly stop: TokenView | null;
 
   /**
    * Parent node; `null`/`undefined` at the root. Upward walks traverse the
@@ -1134,10 +1143,14 @@ export interface ParticipantsCollection {
   Get(name: string): ParticipantView | undefined;
   /** Number of participants. */
   Size(): number;
-  /** Declaration/mention offset ranges `[start, stop + 1]`. Consumer: Participant.tsx:45-48. */
-  GetPositions(name: string): IrPosition[];
-  /** Assignee offset ranges. Consumer: Participant.tsx:45-48. */
-  GetAssigneePositions(name: string): IrPosition[];
+  /**
+   * Declaration/mention offset ranges `[start, stop + 1]`, or `undefined` when
+   * the name is unknown. Consumer normalizes with `Array.from(… ?? [])`
+   * (Participant.tsx:45-48).
+   */
+  GetPositions(name: string): ReadonlySet<IrPosition> | undefined;
+  /** Assignee offset ranges (see {@link ParticipantsCollection.GetPositions}). */
+  GetAssigneePositions(name: string): ReadonlySet<IrPosition> | undefined;
 }
 
 /* ------------------------------------------------------------------------ */


### PR DESCRIPTION
## Why (audit finding N2)

`src/parser/ir/contract.ts` (1269 lines) is the declared v1 IR boundary, but it had **zero enforcement**: no file imported it, and its header falsely claimed the Langium facade classes `implements` these interfaces (the only `implements` in the side-car is one token-builder). With no `tsc` in CI it was drifting into confident-but-wrong documentation. Now that #416 added the typecheck gate, enforcement is finally possible.

## What

- **`compat.ts` now binds its module surface to `ParserModule` with `satisfies`.** Because `ParserModule` types `RootContext`, `Participants`, `Depth`, `Errors`, and the `ProgContext`/`GroupContext`/`ParticipantContext` class members, the CI typecheck gate now fails if the facade drifts from the contract — the facade classes and the `ParticipantsCollection` shape are checked transitively. `contract.ts` finally has an importer.
- **Corrected the false header claim** about `implements`.

## Drift the enforcement surfaced (all reconciled; no consumer-facing behavior change)

Wiring `satisfies` immediately caught three genuine contract-vs-reality mismatches:

1. **`IrNode.stop` was declared `TokenView` (non-null)**, but ANTLR gives a rule that consumed zero parser-visible tokens `stop === null`, and the facade faithfully mirrors this (`facade/nodes.ts` `get stop()`). → contract corrected to `TokenView | null` (the DSL-transform consumers only read `stop` on non-empty nodes).
2. **The `Participant` class marked renderer-facing fields (`type`, `stereotype`, `color`, `emoji`, …) `private`** while already exposing them all publicly via `ToValue()` — inconsistent encapsulation that blocked conformance to `ParticipantView`. → made public (compile-time only; runtime identical).
3. **`ParticipantsCollection.GetPositions`/`GetAssigneePositions` claimed `IrPosition[]`** but actually return `Set<Position> | undefined` (the consumer normalizes with `Array.from(… ?? [])`, `Participant.tsx:45-48`). → contract corrected.

## Verification

- `bunx tsc -b --force` → **0 errors** (the `satisfies` compiles — the facade now provably conforms).
- `bun run test` → **1638 pass / 0 fail**; `bunx eslint src` → 0 errors.
- All three drift fixes are types/visibility only — no runtime change (tests unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)